### PR TITLE
Add OPA Assessments extract, prepare, and load pipeline

### DIFF
--- a/tasks/extract_opa_assessments/main.py
+++ b/tasks/extract_opa_assessments/main.py
@@ -1,0 +1,64 @@
+"""
+Cloud Function to extract OPA Assessments data.
+
+This function downloads the OPA Assessment History dataset as a CSV
+from the City of Philadelphia and uploads to Cloud Storage.
+
+Usage:
+    Deploy as a Cloud Function named "extract-opa-assessments"
+"""
+
+import functions_framework
+import requests
+import os
+from google.cloud import storage
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# Direct CSV download link for OPA Assessments.
+OPA_ASSESSMENTS_URL = "https://opendata-downloads.s3.amazonaws.com/assessments.csv"
+
+
+@functions_framework.http
+def extract_opa_assessments(request):
+    """HTTP Cloud Function to extract OPA Assessments data.
+
+    Downloads the OPA Assessment History CSV file and uploads
+    to Cloud Storage.
+
+    Args:
+        request: The HTTP request object.
+
+    Returns:
+        A response indicating success or failure.
+    """
+    try:
+        raw_data_bucket = os.getenv("RAW_DATA_BUCKET", "musa5090s26-team5-raw_data")
+
+        # Download the assessments CSV file.
+        print("Downloading OPA Assessments CSV.")
+        response = requests.get(OPA_ASSESSMENTS_URL, timeout=1800)
+        response.raise_for_status()
+
+        # Upload to Cloud Storage.
+        storage_client = storage.Client()
+        bucket = storage_client.bucket(raw_data_bucket)
+        blob = bucket.blob("opa_assessments/data.csv")
+
+        print("Uploading CSV to Cloud Storage.")
+        blob.upload_from_string(response.content, content_type="text/csv")
+
+        print(f"Uploaded to gs://{raw_data_bucket}/opa_assessments/data.csv")
+
+        return (
+            "Successfully extracted OPA Assessments as CSV.",
+            200,
+        )
+
+    except requests.exceptions.RequestException as e:
+        print(f"Error fetching data: {e}.")
+        return (f"Error fetching data: {e}.", 500)
+    except Exception as e:
+        print(f"Error: {e}.")
+        return (f"Error: {e}.", 500)

--- a/tasks/extract_opa_assessments/requirements.txt
+++ b/tasks/extract_opa_assessments/requirements.txt
@@ -1,0 +1,4 @@
+functions-framework==3.*
+google-cloud-storage==2.*
+requests==2.*
+python-dotenv==1.*

--- a/tasks/load_opa_assessments/core_opa_assessments.sql
+++ b/tasks/load_opa_assessments/core_opa_assessments.sql
@@ -1,0 +1,10 @@
+-- Create or replace the core table for OPA Assessments.
+-- This table includes all fields from the source table plus a property_id field.
+
+CREATE OR REPLACE TABLE `{project_id}.core.opa_assessments`
+AS (
+    SELECT
+        parcel_number AS property_id,
+        *
+    FROM `{project_id}.source.opa_assessments`
+);

--- a/tasks/load_opa_assessments/main.py
+++ b/tasks/load_opa_assessments/main.py
@@ -1,0 +1,96 @@
+"""
+Cloud Function to load OPA Assessments data into BigQuery.
+
+This function creates or replaces:
+1. An external table in the source dataset backed by the prepared JSON-L file.
+2. An internal table in the core dataset with an added property_id field.
+
+Usage:
+    Deploy as a Cloud Function named "load-opa-assessments"
+"""
+
+import functions_framework
+import pathlib
+import os
+from google.cloud import bigquery
+from dotenv import load_dotenv
+
+load_dotenv()
+
+DIR_NAME = pathlib.Path(__file__).parent
+
+
+def render_template(sql_query_template, context):
+    """Render a SQL template by substituting {var} placeholders.
+
+    Args:
+        sql_query_template: SQL string with {var} placeholders.
+        context: Dictionary of variable names to values.
+
+    Returns:
+        The rendered SQL string.
+    """
+    return sql_query_template.format(**context)
+
+
+def run_sql_file(client, sql_file_path, context):
+    """Execute a SQL file with variable substitution.
+
+    Args:
+        client: BigQuery client instance.
+        sql_file_path: Path to the SQL file.
+        context: Dictionary of variables to substitute in the SQL.
+
+    Returns:
+        The query job result.
+    """
+    with open(sql_file_path, "r", encoding="utf-8") as f:
+        sql_query_template = f.read()
+
+    sql_query = render_template(sql_query_template, context)
+
+    print(f"Executing SQL from {sql_file_path}.")
+    job = client.query(sql_query)
+    # Wait for completion.
+    job.result()
+    return job
+
+
+@functions_framework.http
+def load_opa_assessments(request):
+    """HTTP Cloud Function to load OPA Assessments into BigQuery.
+
+    Creates or replaces the source.opa_assessments external table and
+    the core.opa_assessments internal table.
+
+    Args:
+        request: The HTTP request object.
+
+    Returns:
+        A response indicating success or failure.
+    """
+    try:
+        project_id = os.getenv("GOOGLE_CLOUD_PROJECT", "musa5090s26-team5")
+        client = bigquery.Client()
+
+        # Context for SQL template rendering.
+        context = {
+            "project_id": project_id,
+            "bucket_name": os.getenv(
+                "DATA_LAKE_BUCKET", "musa5090s26-team5-prepared_data"
+            ),
+        }
+
+        # Run the source table SQL.
+        run_sql_file(client, DIR_NAME / "source_opa_assessments.sql", context)
+        print("Created or replaced source.opa_assessments external table.")
+
+        # Run the core table SQL.
+        run_sql_file(client, DIR_NAME / "core_opa_assessments.sql", context)
+        print("Created or replaced core.opa_assessments table.")
+
+        return ("Successfully loaded OPA Assessments into BigQuery.", 200)
+
+    except Exception as e:
+        print(f"Error: {e}.")
+        return (f"Error: {e}.", 500)

--- a/tasks/load_opa_assessments/requirements.txt
+++ b/tasks/load_opa_assessments/requirements.txt
@@ -1,0 +1,3 @@
+functions-framework==3.*
+google-cloud-bigquery==3.*
+python-dotenv==1.*

--- a/tasks/load_opa_assessments/source_opa_assessments.sql
+++ b/tasks/load_opa_assessments/source_opa_assessments.sql
@@ -1,0 +1,9 @@
+-- Create or replace the external table for OPA Assessments.
+-- This table is backed by the Parquet file in Cloud Storage.
+-- Schema is auto-detected from Parquet metadata.
+
+CREATE OR REPLACE EXTERNAL TABLE `{project_id}.source.opa_assessments`
+OPTIONS (
+    format = 'PARQUET',
+    uris = ['gs://{bucket_name}/opa_assessments/data.parquet']
+);

--- a/tasks/prepare_opa_assessments/main.py
+++ b/tasks/prepare_opa_assessments/main.py
@@ -1,0 +1,120 @@
+"""
+Cloud Function to prepare OPA Assessments data for BigQuery.
+
+This function reads the raw OPA Assessments CSV from Cloud Storage,
+processes the data in chunks, and writes to Parquet format.
+
+Usage:
+    Deploy as a Cloud Function named "prepare-opa-assessments"
+"""
+
+import functions_framework
+import os
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+from google.cloud import storage
+from dotenv import load_dotenv
+
+load_dotenv()
+
+CHUNK_SIZE = 200_000
+NUMERIC_COLUMNS = [
+    "market_value",
+    "taxable_building",
+    "taxable_land",
+    "exempt_building",
+    "exempt_land",
+    "year",
+]
+
+
+def process_chunk(chunk_df, parquet_writer, output_file):
+    """Process a DataFrame chunk and append to Parquet.
+
+    Returns the ParquetWriter (created on first call).
+    """
+    # Lowercase column names.
+    chunk_df.columns = [c.lower() for c in chunk_df.columns]
+
+    # Convert numeric columns.
+    for col in NUMERIC_COLUMNS:
+        if col in chunk_df.columns:
+            chunk_df[col] = pd.to_numeric(chunk_df[col], errors="coerce").astype(
+                "float64"
+            )
+
+    table = pa.Table.from_pandas(chunk_df, preserve_index=False)
+
+    if parquet_writer is None:
+        parquet_writer = pq.ParquetWriter(output_file, table.schema)
+    else:
+        table = table.cast(parquet_writer.schema)
+
+    parquet_writer.write_table(table)
+    return parquet_writer
+
+
+@functions_framework.http
+def prepare_opa_assessments(request):
+    """HTTP Cloud Function to prepare OPA Assessments data.
+
+    Reads the raw CSV from Cloud Storage, converts to Parquet in
+    chunks, and uploads to the prepared data bucket.
+
+    Args:
+        request: The HTTP request object.
+
+    Returns:
+        A response indicating success or failure.
+    """
+    try:
+        raw_data_bucket = os.getenv("RAW_DATA_BUCKET", "musa5090s26-team5-raw_data")
+        prepared_data_bucket = os.getenv(
+            "PREPARED_DATA_BUCKET", "musa5090s26-team5-prepared_data"
+        )
+
+        storage_client = storage.Client()
+        raw_blob = storage_client.bucket(raw_data_bucket).blob(
+            "opa_assessments/data.csv"
+        )
+
+        # Download CSV to a temp file.
+        temp_csv = "/tmp/opa_assessments.csv"
+        temp_parquet = "/tmp/opa_assessments.parquet"
+
+        print("Downloading raw OPA Assessments CSV.")
+        raw_blob.download_to_filename(temp_csv)
+
+        # Read CSV in chunks and write to Parquet.
+        print("Processing CSV into Parquet.")
+        parquet_writer = None
+        total_rows = 0
+
+        for chunk_df in pd.read_csv(temp_csv, chunksize=CHUNK_SIZE):
+            parquet_writer = process_chunk(chunk_df, parquet_writer, temp_parquet)
+            total_rows += len(chunk_df)
+            print(f"Processed {total_rows} rows.")
+
+        if parquet_writer:
+            parquet_writer.close()
+
+        print(f"Processed {total_rows} rows total.")
+
+        # Upload to prepared data bucket.
+        prepared_blob = storage_client.bucket(prepared_data_bucket).blob(
+            "opa_assessments/data.parquet"
+        )
+        print("Uploading to Cloud Storage.")
+        prepared_blob.upload_from_filename(temp_parquet)
+
+        print(f"Uploaded to gs://{prepared_data_bucket}/opa_assessments/data.parquet")
+
+        return (
+            f"Successfully prepared {total_rows} OPA assessment records as Parquet.",
+            200,
+        )
+
+    except Exception as e:
+        print(f"Error: {e}.")
+        return (f"Error: {e}.", 500)

--- a/tasks/prepare_opa_assessments/requirements.txt
+++ b/tasks/prepare_opa_assessments/requirements.txt
@@ -1,0 +1,5 @@
+functions-framework==3.*
+google-cloud-storage==2.*
+python-dotenv==1.*
+pandas==2.*
+pyarrow==15.*


### PR DESCRIPTION
# Description

Complete pipeline for ingesting OPA Assessment History data into BigQuery.

Three Cloud Functions:

`extract-opa-assessments`: Fetches the OPA Assessment History dataset as CSV from the Philadelphia open data S3 endpoint and uploads it to gs://musa5090s26-team5-raw_data/opa_assessments/

`prepare-opa-assessments`: Reads the raw CSV in 200k-row chunks, coerces numeric columns (market_value, taxable_building, taxable_land, exempt_building, exempt_land, year) to float64, and writes Parquet to gs://musa5090s26-team5-prepared_data/opa_assessments/data.parquet

`load-opa-assessments`: Creates two BigQuery tables:

`source.opa_assessments`: External table backed by the Parquet file
`core.opa_assessments`: Internal table with all fields from source plus property_id (aliased from parcel_number)

Resolves #2 

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Small fix/change
- [ ] Documentation

Deployment steps to test:

```pwsh
# Deploy each Cloud Function
gcloud functions deploy extract-opa-assessments --runtime python311 --trigger-http --allow-unauthenticated
gcloud functions deploy prepare-opa-assessments --runtime python311 --trigger-http --allow-unauthenticated
gcloud functions deploy load-opa-assessments --runtime python311 --trigger-http --allow-unauthenticated

# Deploy the Workflow
gcloud workflows deploy data-pipeline --location=us-east4 --source=tasks/workflows/data_pipeline.yaml

# Execute the workflow
gcloud workflows run data-pipeline --location=us-east4
```

All functions require the following environment variables to be set:

`GOOGLE_CLOUD_PROJECT`: GCP project ID
`RAW_DATA_BUCKET`: Name of raw data bucket
`PREPARED_DATA_BUCKET`: Name of prepared data bucket
`DATA_LAKE_BUCKET`: Name of prepared data bucket (for load function)

## Post-merge follow-ups

N/A

- [x] No action required
- [ ] Actions required (specified below)