### PR TITLE
Add SEPTA ETL Cloud Functions and SQL

### DIFF
--- a/tasks/extract_septa/main.py
+++ b/tasks/extract_septa/main.py
@@ -1,0 +1,64 @@
+"""
+Cloud Function to extract SEPTA Stations data.
+
+This function downloads the SEPTA Stations dataset as a CSV
+from the City of Philadelphia and uploads to Cloud Storage.
+
+Usage:
+    Deploy as a Cloud Function named "extract-septa"
+"""
+
+import functions_framework
+import requests
+import os
+from google.cloud import storage
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# Direct CSV download link for SEPTA Stations.
+SEPTA_STATIONS_URL = "https://hub.arcgis.com/api/v3/datasets/b227f3ddbe3e47b4bcc7b7c65ef2cef6_0/downloads/data?format=csv&spatialRefId=3857&where=1%3D1"
+
+
+@functions_framework.http
+def extract_septa(request):
+    """HTTP Cloud Function to extract SEPTA Stations data.
+
+    Downloads the SEPTA Stations CSV file and uploads
+    to Cloud Storage.
+
+    Args:
+        request: The HTTP request object.
+
+    Returns:
+        A response indicating success or failure.
+    """
+    try:
+        raw_data_bucket = os.getenv("RAW_DATA_BUCKET", "musa5090s26-team5-raw_data")
+
+        # Download the stations CSV file.
+        print("Downloading SEPTA Stations CSV.")
+        response = requests.get(SEPTA_STATIONS_URL, timeout=1800)
+        response.raise_for_status()
+
+        # Upload to Cloud Storage.
+        storage_client = storage.Client()
+        bucket = storage_client.bucket(raw_data_bucket)
+        blob = bucket.blob("septa/data.csv")
+
+        print("Uploading CSV to Cloud Storage.")
+        blob.upload_from_string(response.content, content_type="text/csv")
+
+        print(f"Uploaded to gs://{raw_data_bucket}/septa/data.csv")
+
+        return (
+            "Successfully extracted SEPTA Stations as CSV.",
+            200,
+        )
+
+    except requests.exceptions.RequestException as e:
+        print(f"Error fetching data: {e}.")
+        return (f"Error fetching data: {e}.", 500)
+    except Exception as e:
+        print(f"Error: {e}.")
+        return (f"Error: {e}.", 500)

--- a/tasks/extract_septa/requirements.txt
+++ b/tasks/extract_septa/requirements.txt
@@ -1,0 +1,4 @@
+functions-framework==3.*
+google-cloud-storage==2.*
+requests==2.*
+python-dotenv==1.*

--- a/tasks/load_septa/core_septa.sql
+++ b/tasks/load_septa/core_septa.sql
@@ -1,0 +1,9 @@
+-- Create or replace the core table for SEPTA Stations.
+-- This table is a simple copy of the source stations data.
+-- Stations are reference/lookup data, not property-specific records.
+
+CREATE OR REPLACE TABLE `{project_id}.core.septa`
+AS (
+    SELECT *
+    FROM `{project_id}.source.septa`
+);

--- a/tasks/load_septa/main.py
+++ b/tasks/load_septa/main.py
@@ -1,12 +1,12 @@
 """
-Cloud Function to load OPA Assessments data into BigQuery.
+Cloud Function to load SEPTA Stations data into BigQuery.
 
 This function creates or replaces:
 1. An external table in the source dataset backed by the prepared Parquet file.
-2. An internal table in the core dataset with an added property_id field.
+2. An internal table in the core dataset.
 
 Usage:
-    Deploy as a Cloud Function named "load-opa-assessments"
+    Deploy as a Cloud Function named "load-septa"
 """
 
 import functions_framework
@@ -57,11 +57,11 @@ def run_sql_file(client, sql_file_path, context):
 
 
 @functions_framework.http
-def load_opa_assessments(request):
-    """HTTP Cloud Function to load OPA Assessments into BigQuery.
+def load_septa(request):
+    """HTTP Cloud Function to load SEPTA Stations into BigQuery.
 
-    Creates or replaces the source.opa_assessments external table and
-    the core.opa_assessments internal table.
+    Creates or replaces the source.septa external table and
+    the core.septa internal table.
 
     Args:
         request: The HTTP request object.
@@ -82,14 +82,14 @@ def load_opa_assessments(request):
         }
 
         # Run the source table SQL.
-        run_sql_file(client, DIR_NAME / "source_opa_assessments.sql", context)
-        print("Created or replaced source.opa_assessments external table.")
+        run_sql_file(client, DIR_NAME / "source_septa.sql", context)
+        print("Created or replaced source.septa external table.")
 
         # Run the core table SQL.
-        run_sql_file(client, DIR_NAME / "core_opa_assessments.sql", context)
-        print("Created or replaced core.opa_assessments table.")
+        run_sql_file(client, DIR_NAME / "core_septa.sql", context)
+        print("Created or replaced core.septa table.")
 
-        return ("Successfully loaded OPA Assessments into BigQuery.", 200)
+        return ("Successfully loaded SEPTA Stations into BigQuery.", 200)
 
     except Exception as e:
         print(f"Error: {e}.")

--- a/tasks/load_septa/requirements.txt
+++ b/tasks/load_septa/requirements.txt
@@ -1,0 +1,3 @@
+functions-framework==3.*
+google-cloud-bigquery==3.*
+python-dotenv==1.*

--- a/tasks/load_septa/source_septa.sql
+++ b/tasks/load_septa/source_septa.sql
@@ -1,0 +1,9 @@
+-- Create or replace the external table for SEPTA Stations.
+-- This table is backed by the Parquet file in Cloud Storage.
+-- Schema is auto-detected from Parquet metadata.
+
+CREATE OR REPLACE EXTERNAL TABLE `{project_id}.source.septa`
+OPTIONS (
+    format = 'PARQUET',
+    uris = ['gs://{bucket_name}/septa/data.parquet']
+);

--- a/tasks/prepare_septa/main.py
+++ b/tasks/prepare_septa/main.py
@@ -1,0 +1,80 @@
+"""
+Cloud Function to prepare SEPTA Stations data for BigQuery.
+
+This function reads the raw SEPTA Stations CSV from Cloud Storage,
+converts it to Parquet format, and writes to the prepared data bucket.
+
+Usage:
+    Deploy as a Cloud Function named "prepare-septa"
+"""
+
+import functions_framework
+import os
+import pandas as pd
+from google.cloud import storage
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+@functions_framework.http
+def prepare_septa(request):
+    """HTTP Cloud Function to prepare SEPTA Stations data.
+
+    Reads the raw CSV from Cloud Storage, converts to Parquet,
+    and uploads to the prepared data bucket.
+
+    Args:
+        request: The HTTP request object.
+
+    Returns:
+        A response indicating success or failure.
+    """
+    try:
+        raw_data_bucket = os.getenv("RAW_DATA_BUCKET", "musa5090s26-team5-raw_data")
+        prepared_data_bucket = os.getenv(
+            "PREPARED_DATA_BUCKET", "musa5090s26-team5-prepared_data"
+        )
+
+        storage_client = storage.Client()
+        raw_blob = storage_client.bucket(raw_data_bucket).blob(
+            "septa/data.csv"
+        )
+
+        # Download CSV to a temp file.
+        temp_csv = "/tmp/septa.csv"
+        temp_parquet = "/tmp/septa.parquet"
+
+        print("Downloading raw SEPTA Stations CSV.")
+        raw_blob.download_to_filename(temp_csv)
+
+        # Read CSV and convert to Parquet.
+        print("Processing CSV into Parquet.")
+        df = pd.read_csv(temp_csv)
+
+        # Lowercase column names.
+        df.columns = [c.lower() for c in df.columns]
+
+        print(f"Processing {len(df)} records.")
+
+        # Write Parquet to temp file.
+        print("Writing Parquet file.")
+        df.to_parquet(temp_parquet, index=False)
+
+        # Upload to prepared data bucket.
+        prepared_blob = storage_client.bucket(prepared_data_bucket).blob(
+            "septa/data.parquet"
+        )
+        print("Uploading to Cloud Storage.")
+        prepared_blob.upload_from_filename(temp_parquet)
+
+        print(f"Uploaded to gs://{prepared_data_bucket}/septa/data.parquet")
+
+        return (
+            f"Successfully prepared {len(df)} SEPTA stations records as Parquet.",
+            200,
+        )
+
+    except Exception as e:
+        print(f"Error: {e}.")
+        return (f"Error: {e}.", 500)

--- a/tasks/prepare_septa/requirements.txt
+++ b/tasks/prepare_septa/requirements.txt
@@ -1,0 +1,5 @@
+functions-framework==3.*
+google-cloud-storage==2.*
+python-dotenv==1.*
+pandas==2.*
+pyarrow==15.*


### PR DESCRIPTION
# Description

Add extract, prepare, and load pipeline for SEPTA Stations reference data, following the established pattern from issues #1-3 for OPA Properties, OPA Assessments, and PWD Parcels.

This implementation adds support for ingesting SEPTA station locations as a reference dataset to support downstream analysis and queries. The data flows through the standard three-stage pipeline: extract (CSV from ArcGIS Hub) -> prepare (convert to Parquet) -> load (create BigQuery external and core tables).

**Related to:** #1, #2, #3 (establishes consistent data pipeline patterns)

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Small fix/change
- [ ] Documentation

## What should the reviewer know?

The SEPTA pipeline introduces a key difference from property datasets: stations are reference/lookup data (not property-specific geometry). Consequently:

- **Extract** downloads CSV directly from ArcGIS Hub (no GeoJSON conversion needed)
- **Prepare** converts CSV to Parquet with lowercase column names (no special geometry handling required)
- **Load** creates simple copies in both source and core tables (no `property_id` field added, as stations aren't tied to individual properties)

Files added:
- `tasks/extract_septa/main.py` and requirements.txt
- `tasks/prepare_septa/main.py` and requirements.txt
- `tasks/load_septa/main.py` and requirements.txt
- `tasks/load_septa/source_septa.sql` and `core_septa.sql`

To test locally (after deployment):
```pwsh
gcloud functions call extract-septa --region=us-east4
gcloud functions call prepare-septa --region=us-east4
gcloud functions call load-septa --region=us-east4
```

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)