### PR TITLE
Add MapLibre map and update UI files

### DIFF
--- a/ui/configs/dummy_current_assessment_bins.json
+++ b/ui/configs/dummy_current_assessment_bins.json
@@ -1,0 +1,12 @@
+[
+  {"lower_bound": 0, "upper_bound": 100000, "property_count": 105000},
+  {"lower_bound": 100000, "upper_bound": 200000, "property_count": 98000},
+  {"lower_bound": 200000, "upper_bound": 300000, "property_count": 68000},
+  {"lower_bound": 300000, "upper_bound": 400000, "property_count": 42000},
+  {"lower_bound": 400000, "upper_bound": 500000, "property_count": 25000},
+  {"lower_bound": 500000, "upper_bound": 750000, "property_count": 18000},
+  {"lower_bound": 750000, "upper_bound": 1000000, "property_count": 10500},
+  {"lower_bound": 1000000, "upper_bound": 2000000, "property_count": 5800},
+  {"lower_bound": 2000000, "upper_bound": 3500000, "property_count": 2400},
+  {"lower_bound": 3500000, "upper_bound": 999999999, "property_count": 900}
+]

--- a/ui/configs/dummy_tax_year_assessment_bins.json
+++ b/ui/configs/dummy_tax_year_assessment_bins.json
@@ -1,0 +1,12 @@
+[
+  {"lower_bound": 0, "upper_bound": 100000, "property_count": 120000},
+  {"lower_bound": 100000, "upper_bound": 200000, "property_count": 95000},
+  {"lower_bound": 200000, "upper_bound": 300000, "property_count": 62000},
+  {"lower_bound": 300000, "upper_bound": 400000, "property_count": 38000},
+  {"lower_bound": 400000, "upper_bound": 500000, "property_count": 22000},
+  {"lower_bound": 500000, "upper_bound": 750000, "property_count": 15000},
+  {"lower_bound": 750000, "upper_bound": 1000000, "property_count": 8500},
+  {"lower_bound": 1000000, "upper_bound": 2000000, "property_count": 4200},
+  {"lower_bound": 2000000, "upper_bound": 3500000, "property_count": 1800},
+  {"lower_bound": 3500000, "upper_bound": 999999999, "property_count": 600}
+]

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,10 +1,15 @@
 <!doctype html>
 <html lang="en">
 
+<!-- Landing page. Links out to two main sub-applications. -->
 <head>
   <meta charset="utf-8" />
   <title>MUSA 5090 - CAMA Project</title>
 
+  <!--
+    Inline styles used here since this is a single-page landing with no
+    shared components. No external stylesheet is needed.
+  -->
   <style>
     body {
       font-family: sans-serif;
@@ -12,6 +17,7 @@
       padding: 0;
     }
 
+    /* Center nav cards vertically and horizontally on full viewport. */
     main {
       display: flex;
       flex-direction: column;
@@ -30,12 +36,14 @@
       gap: 1rem;
     }
 
+    /* Stack nav cards vertically on portrait-oriented screens (e.g. mobile) */
     @media (orientation: portrait) {
       nav {
         flex-direction: column;
       }
     }
 
+    /* Nav cards styled as clickable tiles. */
     a {
       display: block;
       padding: 2rem;
@@ -47,6 +55,7 @@
       transition: all 0.2s ease-in-out;
     }
 
+    /* Subtle lift effect on hover. */
     a:hover {
       background-color: #f5f5f5;
       box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
@@ -58,6 +67,7 @@
 <body>
   <main>
     <h1>MUSA 5090 - CAMA Project</h1>
+    <!-- Links to two sub-applications. -->
     <nav>
       <a href="./reviewer">Tax Assessor Review UI</a>
       <a href="./widget">Property Owner Widget UI</a>

--- a/ui/reviewer/index.html
+++ b/ui/reviewer/index.html
@@ -8,6 +8,7 @@
   <!-- MapLibre GL JS stylesheet. Required for map canvas, controls, and popups. -->
   <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.5.0/dist/maplibre-gl.css" />
   <link rel="stylesheet" href="styles.css" />
+  <script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
 </head>
 
 <body>
@@ -28,36 +29,17 @@
       </div>
 
       <!-- Chart. Distribution of current (ML-predicted) assessment values.
-           Will be driven by /configs/current_assessment_bins.json (issue #5/#19). -->
+           Driven by current_assessment_bins.json (issue #5/#19). -->
       <section class="chart-section">
-        <h2>Current Assessment Value Distribution&hellip;</h2>
-        <div class="chart-container" id="value-distribution-chart">
-          <div class="chart-placeholder">
-            <span class="chart-y-label"># Properties</span>
-            <div class="chart-area"></div>
-            <div class="chart-x-labels">
-              <span>$5,000</span>
-              <span>$3,500,000</span>
-            </div>
-          </div>
-        </div>
+        <h2>Predicted Assessment Value Distribution</h2>
+        <div class="chart-container" id="current-assessment-chart"></div>
       </section>
 
-      <!-- Chart. Distribution of % change between ML-predicted value
-           and most recent tax year assessed value (issue #18). -->
+      <!-- Chart. Distribution of assessed property values for the most
+           recent tax year (issue #18). Driven by tax_year_assessment_bins.json. -->
       <section class="chart-section">
-        <h2>Percent Change Since Last Assessment&hellip;</h2>
-        <div class="chart-container" id="pct-change-chart">
-          <div class="chart-placeholder">
-            <span class="chart-y-label"># Properties</span>
-            <div class="chart-area"></div>
-            <div class="chart-x-labels">
-              <span>-50%</span>
-              <span>0%</span>
-              <span>200%</span>
-            </div>
-          </div>
-        </div>
+        <h2>Tax Year Assessment Value Distribution</h2>
+        <div class="chart-container" id="tax-year-chart"></div>
       </section>
     </aside>
 
@@ -151,6 +133,138 @@
 
     // Add zoom (+/−) and compass rotation controls to the top-left corner.
     map.addControl(new maplibregl.NavigationControl(), "top-left");
+  </script>
+
+  <script>
+    // Tax Year Assessment Value Distribution Chart
+    // Fetch from public GCS bucket in future:
+    // https://storage.googleapis.com/musa5090s26-team5-public/configs/tax_year_assessment_bins.json
+    // Below currently uses local dummy data file.
+    const TAX_YEAR_BINS_URL = "../configs/dummy_tax_year_assessment_bins.json";
+
+    function formatDollar(value) {
+      if (value >= 1_000_000) return "$" + (value / 1_000_000).toFixed(1) + "M";
+      if (value >= 1_000) return "$" + (value / 1_000).toFixed(0) + "K";
+      return "$" + value;
+    }
+
+    fetch(TAX_YEAR_BINS_URL)
+      .then((res) => res.json())
+      .then((bins) => {
+        const categories = bins.map((b) => {
+          const upper = b.upper_bound >= 999_999_999 ? "+" : " \u2013 " + formatDollar(b.upper_bound);
+          return formatDollar(b.lower_bound) + upper;
+        });
+        const counts = bins.map((b) => b.property_count);
+
+        const options = {
+          chart: {
+            type: "bar",
+            height: 220,
+            toolbar: { show: false },
+            fontFamily: '"Helvetica Neue", Helvetica, Arial, sans-serif',
+          },
+          series: [{ name: "Properties", data: counts }],
+          xaxis: {
+            categories,
+            labels: {
+              rotate: -45,
+              rotateAlways: true,
+              style: { fontSize: "10px" },
+            },
+          },
+          yaxis: {
+            title: { text: "# Properties" },
+            labels: {
+              formatter: (val) => val >= 1000 ? (val / 1000).toFixed(0) + "K" : val,
+            },
+          },
+          colors: ["#2C3968"],
+          plotOptions: {
+            bar: { borderRadius: 2, columnWidth: "70%" },
+          },
+          dataLabels: { enabled: false },
+          tooltip: {
+            y: {
+              formatter: (val) => val.toLocaleString() + " properties",
+            },
+          },
+        };
+
+        const chart = new ApexCharts(
+          document.querySelector("#tax-year-chart"),
+          options
+        );
+        chart.render();
+      })
+      .catch((err) => {
+        console.error("Failed to load tax year assessment bins:", err);
+        document.querySelector("#tax-year-chart").textContent =
+          "Chart data unavailable.";
+      });
+  </script>
+
+  <script>
+    // Predicted (Current) Assessment Value Distribution Chart
+    // Fetch from public GCS bucket in future:
+    // https://storage.googleapis.com/musa5090s26-team5-public/configs/current_assessment_bins.json
+    // Below currently uses local dummy data file.
+    const CURRENT_BINS_URL = "../configs/dummy_current_assessment_bins.json";
+
+    fetch(CURRENT_BINS_URL)
+      .then((res) => res.json())
+      .then((bins) => {
+        const categories = bins.map((b) => {
+          const upper = b.upper_bound >= 999_999_999 ? "+" : " \u2013 " + formatDollar(b.upper_bound);
+          return formatDollar(b.lower_bound) + upper;
+        });
+        const counts = bins.map((b) => b.property_count);
+
+        const options = {
+          chart: {
+            type: "bar",
+            height: 220,
+            toolbar: { show: false },
+            fontFamily: '"Helvetica Neue", Helvetica, Arial, sans-serif',
+          },
+          series: [{ name: "Properties", data: counts }],
+          xaxis: {
+            categories,
+            labels: {
+              rotate: -45,
+              rotateAlways: true,
+              style: { fontSize: "10px" },
+            },
+          },
+          yaxis: {
+            title: { text: "# Properties" },
+            labels: {
+              formatter: (val) => val >= 1000 ? (val / 1000).toFixed(0) + "K" : val,
+            },
+          },
+          colors: ["#F2541B"],
+          plotOptions: {
+            bar: { borderRadius: 2, columnWidth: "70%" },
+          },
+          dataLabels: { enabled: false },
+          tooltip: {
+            y: {
+              formatter: (val) => val.toLocaleString() + " properties",
+            },
+          },
+        };
+
+        const chart = new ApexCharts(
+          document.querySelector("#current-assessment-chart"),
+          options
+        );
+        chart.render();
+      })
+      .catch((err) => {
+        console.error("Failed to load current assessment bins:", err);
+        document.querySelector("#current-assessment-chart").textContent =
+          "Chart data unavailable.";
+      });
   </script>
 </body>
 

--- a/ui/reviewer/index.html
+++ b/ui/reviewer/index.html
@@ -4,6 +4,8 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <!-- Prevents 300ms tap delay on mobile browsers (iOS Safari, Chrome). -->
+  <meta name="mobile-web-app-capable" content="yes" />
   <title>Mass Appraisal Reviewer</title>
   <!-- MapLibre GL JS stylesheet. Required for map canvas, controls, and popups. -->
   <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.5.0/dist/maplibre-gl.css" />

--- a/ui/reviewer/index.html
+++ b/ui/reviewer/index.html
@@ -205,6 +205,7 @@
   </script>
 
   <script>
+    
     // Predicted (Current) Assessment Value Distribution Chart
     // Fetch from public GCS bucket in future:
     // https://storage.googleapis.com/musa5090s26-team5-public/configs/current_assessment_bins.json

--- a/ui/reviewer/index.html
+++ b/ui/reviewer/index.html
@@ -5,6 +5,8 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Mass Appraisal Reviewer</title>
+  <!-- MapLibre GL JS stylesheet. Required for map canvas, controls, and popups. -->
+  <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.5.0/dist/maplibre-gl.css" />
   <link rel="stylesheet" href="styles.css" />
 </head>
 
@@ -14,6 +16,8 @@
     <aside class="sidebar">
       <h1>Mass Appraisal Reviewer</h1>
 
+      <!-- Summary stats, these numbers will be populated dynamically
+           from assessment data once pipeline data is available. -->
       <div class="summary">
         <p>
           There were <strong>350,626</strong> properties that
@@ -23,6 +27,8 @@
         </p>
       </div>
 
+      <!-- Chart. Distribution of current (ML-predicted) assessment values.
+           Will be driven by /configs/current_assessment_bins.json (issue #5/#19). -->
       <section class="chart-section">
         <h2>Current Assessment Value Distribution&hellip;</h2>
         <div class="chart-container" id="value-distribution-chart">
@@ -37,6 +43,8 @@
         </div>
       </section>
 
+      <!-- Chart. Distribution of % change between ML-predicted value
+           and most recent tax year assessed value (issue #18). -->
       <section class="chart-section">
         <h2>Percent Change Since Last Assessment&hellip;</h2>
         <div class="chart-container" id="pct-change-chart">
@@ -55,6 +63,8 @@
 
     <!-- Main Map Area -->
     <main class="map-area">
+      <!-- Layer toggle panel. Controls which vector tile data layers are shown
+           on map. Checkbox values correspond to layer IDs added in issue #16. -->
       <div class="map-controls">
         <fieldset>
           <legend class="visually-hidden">Map Layers</legend>
@@ -77,9 +87,11 @@
         </fieldset>
       </div>
 
+      <!-- Map container. Sized to fill remaining viewport via CSS.
+           MapLibre GL JS mounts canvas into this element. -->
       <div id="map"></div>
 
-      <!-- Example property popup (hidden by default, shown on click) -->
+      <!-- Example property popup (hidden by default, shown on click). -->
       <div class="property-popup" id="property-popup" hidden>
         <h3 class="popup-address">1234 Sesame St</h3>
         <table class="popup-details">
@@ -99,6 +111,47 @@
       </div>
     </main>
   </div>
+
+  <script src="https://unpkg.com/maplibre-gl@5.5.0/dist/maplibre-gl.js"></script>
+  <script>
+    // Initialize MapLibre GL JS map centered on Philadelphia.
+    // Basemap uses CARTO Positron raster tiles. Neutral light-grey style
+    // for choropleths to stand out.
+    // Vector property tiles (issue #16) will be layered on top of basemap.
+    const map = new maplibregl.Map({
+      container: "map", // ID of DOM element to render map into.
+      style: {
+        version: 8, // MapLibre style specification version.
+        sources: {
+          "carto-light": {
+            type: "raster", // Raster tiles load fast at city-wide zoom levels.
+            tiles: [
+              // Three subdomains for parallel tile fetching / load balancing.
+              "https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png",
+              "https://b.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png",
+              "https://c.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png",
+            ],
+            tileSize: 256,
+            attribution: "&copy; <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors &copy; <a href='https://carto.com/attributions'>CARTO</a>",
+          },
+        },
+        layers: [
+          {
+            id: "carto-light-layer",
+            type: "raster",
+            source: "carto-light",
+            minzoom: 0,
+            maxzoom: 19,
+          },
+        ],
+      },
+      center: [-75.1652, 39.9526], // Philadelphia city center [longitude, latitude].
+      zoom: 11, // City-wide view. Shows all of Philadelphia at load.
+    });
+
+    // Add zoom (+/−) and compass rotation controls to the top-left corner.
+    map.addControl(new maplibregl.NavigationControl(), "top-left");
+  </script>
 </body>
 
 </html>

--- a/ui/reviewer/styles.css
+++ b/ui/reviewer/styles.css
@@ -247,3 +247,108 @@ strong, b {
   white-space: nowrap;
   border: 0;
 }
+
+/* Mobile Responsive
+   
+   Two breakpoints used:
+   - 768px for tablets in portrait and large phones in landscape.
+   - 480px for small phones (iPhone SE, Galaxy S series, Pixel, etc.).
+
+   Stack sidebar above map, shrink padding/font sizes, and reposition
+   floating panels so they don't obscure the map. MapLibre GL JS handles
+   touch/pinch-zoom natively apprently, so no JS changes needed. */
+
+/* Tablet / Small Laptop (≤ 768px)
+   Stack sidebar above map instead of side-by-side.
+   Sidebar becomes scrollable top panel capped at 40 vh. */
+@media (max-width: 768px) {
+  .layout {
+    flex-direction: column; /* Sidebar on top, map below. */
+  }
+
+  .sidebar {
+    width: 100%;
+    min-width: unset; /* Remove desktop min. */
+    max-height: 40vh; /* Cap sidebar height so map stays visible. */
+    border-right: none;
+    border-bottom: 1px solid #ddd; /* Horizontal divider replaces vertical. */
+    padding: 16px 20px;
+  }
+
+  .sidebar h1 {
+    font-size: 1.25rem;
+  }
+
+  /* Map fills remaining viewport below sidebar. */
+  .map-area {
+    min-height: 50vh;
+  }
+
+  /* Shrink layer-toggle panel so it doesn't cover too much of map. */
+  .map-controls {
+    font-size: 0.75rem;
+    padding: 8px 10px;
+    max-width: 70vw; /* Prevent overflow on narrow screens. */
+  }
+
+  /* Move property popup to bottom-center for thumb reach. */
+  .property-popup {
+    right: 50%;
+    transform: translateX(50%);
+    bottom: 16px;
+    max-width: 85vw;
+  }
+}
+
+/* Small Phone (≤ 480px)
+   Tighten spacing. Reduce chart heights. */
+@media (max-width: 480px) {
+  .sidebar {
+    padding: 12px 14px;
+    max-height: 35vh; /* Slightly less room for sidebar on small screens. */
+  }
+
+  .sidebar h1 {
+    font-size: 1.1rem;
+    margin-bottom: 10px;
+  }
+
+  .summary {
+    font-size: 0.85rem;
+    margin-bottom: 16px;
+  }
+
+  .chart-section {
+    margin-bottom: 18px;
+  }
+
+  .chart-section h2 {
+    font-size: 0.78rem;
+  }
+
+  /* Reduce chart placeholder height for small viewport. */
+  .chart-area {
+    height: 70px;
+  }
+
+  /* Stack labels vertically with smaller text. */
+  .map-controls {
+    font-size: 0.7rem;
+    padding: 6px 8px;
+    top: 8px;
+    right: 8px;
+    max-width: 80vw;
+  }
+
+  .map-controls label {
+    gap: 4px;
+    margin-bottom: 4px;
+  }
+
+  /* Popup fills most of screen width on small phones. */
+  .property-popup {
+    max-width: 92vw;
+    font-size: 0.8rem;
+    padding: 10px 12px;
+  }
+}

--- a/ui/reviewer/styles.css
+++ b/ui/reviewer/styles.css
@@ -1,4 +1,10 @@
-/* Reset & Base */
+/* Reviewer UI: styles.css
+   Assessment review dashboard for tax assessors.
+   Layout: fixed-width sidebar (charts + summary) | flex-fill map area */
+
+/* Reset and Base
+   Normalizes box model and removes browser default spacing
+   so layout behaves consistently across browsers. */
 
 *,
 *::before,
@@ -9,32 +15,37 @@
 }
 
 html, body {
-  height: 100%;
+  height: 100%; /* Required so the full-viewport flex layout works. */
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   color: #232323;
   background: #fff;
 }
 
 a {
-  color: #F2541B;
+  color: #F2541B; /* Orange. */
 }
 
 a:hover {
-  color: #c23d0e;
+  color: #c23d0e; /* Darker shade for contrast on hover. */
 }
 
 strong, b {
-  color: #F2541B;
+  color: #F2541B; /* Brand orange for bold text. */
 }
 
-/* Layout */
+/* Layout
+   Two-column flex row. Sidebar on left, map fills rest.
+   100vh keeps the entire UI within one screen with no page scroll. */
 
 .layout {
   display: flex;
   height: 100vh;
 }
 
-/* Sidebar */
+/* Sidebar
+   Fixed-width panel containing title, summary stats, and charts.
+   flex-shrink: 0 prevents sidebar from collapsing as map grows.
+   overflow-y: auto lets chart content scroll if window is short. */
 
 .sidebar {
   width: 360px;
@@ -49,7 +60,7 @@ strong, b {
 .sidebar h1 {
   font-size: 1.5rem;
   font-weight: 700;
-  color: #2C3968;
+  color: #2C3968; /* Navy. */
   margin-bottom: 16px;
 }
 
@@ -59,7 +70,9 @@ strong, b {
   font-size: 0.95rem;
 }
 
-/* Chart Sections */
+/* Chart Sections
+   Placeholder layout used before a charting library replaces .chart-placeholder with a real chart canvas.
+   y-label is rotated vertically to sit flush against chart edge. */
 
 .chart-section {
   margin-bottom: 28px;
@@ -67,7 +80,7 @@ strong, b {
 
 .chart-section h2 {
   font-size: 0.85rem;
-  font-weight: 400;
+  font-weight: 400; /* Light weight to read as a label, not a heading. */
   color: #555;
   margin-bottom: 8px;
 }
@@ -77,7 +90,7 @@ strong, b {
 }
 
 .chart-placeholder {
-  position: relative;
+  position: relative; /* Needed to absolutely position y-axis label. */
   display: flex;
   flex-direction: column;
 }
@@ -85,7 +98,7 @@ strong, b {
 .chart-y-label {
   font-size: 0.7rem;
   color: #888;
-  writing-mode: vertical-rl;
+  writing-mode: vertical-rl; /* Rotate text to run bottom-to-top. */
   transform: rotate(180deg);
   position: absolute;
   left: 0;
@@ -94,8 +107,8 @@ strong, b {
 
 .chart-area {
   height: 100px;
-  margin-left: 24px;
-  background: #D8D7B1;
+  margin-left: 24px; /* Leaves space for rotated y-axis label. */
+  background: #D8D7B1; /* Warm grey placeholder fill. */
   border-radius: 4px;
   border-bottom: 1px solid #ccc;
   border-left: 1px solid #ccc;
@@ -103,34 +116,43 @@ strong, b {
 
 .chart-x-labels {
   display: flex;
-  justify-content: space-between;
+  justify-content: space-between; /* Pin min label left, max label right. */
   margin-left: 24px;
   margin-top: 4px;
   font-size: 0.7rem;
   color: #888;
 }
 
-/* Map Area */
+/* Map Area
+   Fills all remaining horizontal space after sidebar.
+   Position: relative creates a stacking context so that absolutely
+   positioned children (controls, popup) layer correctly over the map.
+   Background color shows briefly before MapLibre tiles load. */
 
 .map-area {
   flex: 1;
   position: relative;
-  background: #e8e0d8;
+  background: #e8e0d8; /* Warm grey tile-loading fallback. */
 }
 
+/* MapLibre GL JS mounts its <canvas> inside this element.
+   Must be 100% x 100% so the canvas fills the available area. */
 #map {
   width: 100%;
   height: 100%;
 }
 
-/* Map Controls (Layer Toggles) */
+/* Map Controls (Layer Toggles)
+   Floating panel anchored to top-right corner of map.
+   z-index 1000 keeps it above MapLibre GL canvas (z-index 0).
+   Semi-transparent white background lets map context show through. */
 
 .map-controls {
   position: absolute;
   top: 12px;
   right: 12px;
   z-index: 1000;
-  background: rgb(255 255 255 / 95%);
+  background: rgb(255 255 255 / 95%); /* Semi-transparent white. */
   border: 1px solid #ccc;
   border-radius: 4px;
   padding: 10px 14px;
@@ -139,7 +161,7 @@ strong, b {
 }
 
 .map-controls fieldset {
-  border: none;
+  border: none; /* <fieldset> has default border. Remove for clean styling */
 }
 
 .map-controls label {
@@ -147,11 +169,11 @@ strong, b {
   align-items: center;
   gap: 6px;
   margin-bottom: 6px;
-  cursor: pointer;
+  cursor: pointer; /* Entire label row is clickable, not just checkbox. */
 }
 
 .map-controls label:last-child {
-  margin-bottom: 0;
+  margin-bottom: 0; /* Remove trailing gap after last toggle. */
 }
 
 .map-controls input[type="checkbox"] {
@@ -160,7 +182,10 @@ strong, b {
   cursor: pointer;
 }
 
-/* Property Popup */
+/* Property Popup
+   Shown when user clicks a property on map.
+   Absolutely positioned over the map. Toggled via hidden attribute in JS.
+   Floated away from layer-toggle panel (bottom-right) to avoid overlap. */
 
 .property-popup {
   position: absolute;
@@ -182,7 +207,7 @@ strong, b {
 }
 
 .popup-details {
-  border-collapse: collapse;
+  border-collapse: collapse; /* Remove default cell spacing in details table. */
 }
 
 .popup-details td {
@@ -196,9 +221,10 @@ strong, b {
 }
 
 .popup-value {
-  text-align: right;
+  text-align: right; /* Align dollar values to right for easy scanning. */
 }
 
+/* Color-coded change indicators: navy = increase, orange = decrease. */
 .popup-change-up {
   color: #2C3968;
 }
@@ -208,7 +234,8 @@ strong, b {
 }
 
 /* Utility */
-
+/* Visually hides element while keeping accessible to screen readers.
+   Used on <legend> inside layer toggle fieldset. */
 .visually-hidden {
   position: absolute;
   width: 1px;

--- a/ui/reviewer/styles.css
+++ b/ui/reviewer/styles.css
@@ -233,8 +233,8 @@ strong, b {
   color: #F2541B;
 }
 
-/* Utility */
-/* Visually hides element while keeping accessible to screen readers.
+/* Utility
+   Visually hides element while keeping accessible to screen readers.
    Used on <legend> inside layer toggle fieldset. */
 .visually-hidden {
   position: absolute;
@@ -261,7 +261,7 @@ strong, b {
 /* Tablet / Small Laptop (≤ 768px)
    Stack sidebar above map instead of side-by-side.
    Sidebar becomes scrollable top panel capped at 40 vh. */
-@media (max-width: 768px) {
+@media (max-width <= 768px) {
   .layout {
     flex-direction: column; /* Sidebar on top, map below. */
   }
@@ -302,7 +302,7 @@ strong, b {
 
 /* Small Phone (≤ 480px)
    Tighten spacing. Reduce chart heights. */
-@media (max-width: 480px) {
+@media (max-width <= 480px) {
   .sidebar {
     padding: 12px 14px;
     max-height: 35vh; /* Slightly less room for sidebar on small screens. */

--- a/ui/reviewer/styles.css
+++ b/ui/reviewer/styles.css
@@ -261,7 +261,7 @@ strong, b {
 /* Tablet / Small Laptop (≤ 768px)
    Stack sidebar above map instead of side-by-side.
    Sidebar becomes scrollable top panel capped at 40 vh. */
-@media (max-width <= 768px) {
+@media (width <= 768px) {
   .layout {
     flex-direction: column; /* Sidebar on top, map below. */
   }
@@ -302,7 +302,7 @@ strong, b {
 
 /* Small Phone (≤ 480px)
    Tighten spacing. Reduce chart heights. */
-@media (max-width <= 480px) {
+@media (width <= 480px) {
   .sidebar {
     padding: 12px 14px;
     max-height: 35vh; /* Slightly less room for sidebar on small screens. */

--- a/ui/widget/index.html
+++ b/ui/widget/index.html
@@ -22,9 +22,13 @@
     <div class="lookup-bar">
       <label for="opa-id-input">Look up a property</label>
       <div class="lookup-input-group">
+        <!-- inputmode="numeric" shows numeric keyboard on mobile phones
+             since OPA account numbers are 9-10 digits. -->
         <input
           type="text"
           id="opa-id-input"
+          inputmode="numeric"
+          pattern="[0-9]*"
           placeholder="Enter OPA Account Number"
           autocomplete="off"
         />

--- a/ui/widget/index.html
+++ b/ui/widget/index.html
@@ -1,10 +1,13 @@
 <!doctype html>
 <html lang="en">
 
+<!-- Property owner widget. Embeddable UI for looking up property's valuation history.
+     Intended to function like a component that could be dropped into atlas.phila.gov. -->
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Valuation History</title>
+  <!-- Open Sans matches Philadelphia city design standards (phila.gov). -->
   <link
     rel="stylesheet"
     href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&display=swap"
@@ -14,7 +17,8 @@
 
 <body>
   <div class="widget-container">
-    <!-- OPA ID Lookup -->
+    <!-- OPA ID Lookup. User enters 9-10 digit OPA account number to fetch
+         assessment history. TO-DO: Replace with address autocomplete input. -->
     <div class="lookup-bar">
       <label for="opa-id-input">Look up a property</label>
       <div class="lookup-input-group">
@@ -32,6 +36,7 @@
     <section class="valuation-history">
       <h2 class="section-heading">
         Valuation History
+        <!-- Record count is updated dynamically via JS after data is fetched. -->
         <span class="record-count" id="record-count">(0)</span>
       </h2>
 
@@ -44,9 +49,11 @@
         the improvement and the portion of value attributed to the land.)
       </p>
 
-      <!-- Chart Area -->
+      <!-- Chart Area. Placeholder replaced by bar/line chart (issue #18/#19)
+           once user performs lookup and data is fetched from API. -->
       <div class="chart-wrapper">
         <div class="chart-container" id="valuation-chart">
+          <!-- Shown before a lookup is performed. Hidden once chart renders. -->
           <div class="chart-placeholder">
             <p class="chart-placeholder-text">
               Enter an OPA account number above to view the valuation history chart.
@@ -69,7 +76,7 @@
             </tr>
           </thead>
           <tbody id="valuation-table-body">
-            <!-- Example rows (will be populated dynamically) -->
+            <!-- Example rows (will be populated dynamically). -->
             <tr>
               <td>2023</td>
               <td>$152,000</td>

--- a/ui/widget/styles.css
+++ b/ui/widget/styles.css
@@ -198,3 +198,101 @@ strong, b {
 .valuation-table tbody tr:hover {
   background: #D8D7B1; /* Warm grey hover matches page background. */
 }
+
+/* Mobile Responsive
+   
+   Two breakpoints used:
+   - 768px for ablets in portrait and large phones in landscape.
+   - 480px for small phones (iPhone SE, Galaxy S series, Pixel, etc.).
+
+   Widget is already mostly responsive thanks to max-width + auto margin
+   and overflow-x: auto on table. */
+
+/* Tablet / Large Phone (≤ 768px)
+   Reduce outer margin and padding. Table already scrolls horizontally. */
+@media (max-width: 768px) {
+  .widget-container {
+    margin: 16px 12px; /* Reduce margins so widget uses more screen width. */
+  }
+
+  .valuation-history {
+    padding: 16px;
+  }
+
+  .section-description {
+    font-size: 0.82rem;
+  }
+
+  /* Make chart shorter on tablets to leave room for table. */
+  .chart-container {
+    min-height: 170px;
+  }
+
+  .chart-placeholder {
+    height: 170px;
+  }
+
+  /* Ensure table cells have enough padding for touch targets. */
+  .valuation-table thead th,
+  .valuation-table tbody td {
+    padding: 10px 8px;
+  }
+}
+
+/* Small Phone (≤ 480px)
+   Edge-to-edge layout. Larger touch targets. Reduced font sizes. */
+@media (max-width: 480px) {
+  .widget-container {
+    margin: 0; /* Full-bleed on small phones. */
+    border-left: none;
+    border-right: none;
+  }
+
+  /* Increase input/button height for thumb (≥ 44px).
+     Matches Apple HIG and Material Design minimum touch target. */
+  .lookup-input-group input {
+    padding: 12px;
+    font-size: 1rem; /* 16px prevents iOS auto-zoom on focus. */
+  }
+
+  .lookup-input-group button {
+    padding: 12px 16px;
+    font-size: 0.9rem;
+  }
+
+  .lookup-bar {
+    padding: 14px 14px;
+  }
+
+  .valuation-history {
+    padding: 14px 12px;
+  }
+
+  .section-heading {
+    font-size: 1rem;
+  }
+
+  .section-description {
+    font-size: 0.8rem;
+    margin-bottom: 14px;
+  }
+
+  /* Compact chart on very small screens. */
+  .chart-container {
+    min-height: 150px;
+  }
+
+  .chart-placeholder {
+    height: 150px;
+  }
+
+  /* Smaller table text to reduce horizontal overflow. */
+  .valuation-table {
+    font-size: 0.78rem;
+  }
+
+  .valuation-table thead th,
+  .valuation-table tbody td {
+    padding: 8px 6px;
+  }
+}

--- a/ui/widget/styles.css
+++ b/ui/widget/styles.css
@@ -210,7 +210,7 @@ strong, b {
 
 /* Tablet / Large Phone (≤ 768px)
    Reduce outer margin and padding. Table already scrolls horizontally. */
-@media (max-width <= 768px) {
+@media (width <= 768px) {
   .widget-container {
     margin: 16px 12px; /* Reduce margins so widget uses more screen width. */
   }
@@ -241,7 +241,7 @@ strong, b {
 
 /* Small Phone (≤ 480px)
    Edge-to-edge layout. Larger touch targets. Reduced font sizes. */
-@media (max-width <= 480px) {
+@media (width <= 480px) {
   .widget-container {
     margin: 0; /* Full-bleed on small phones. */
     border-left: none;

--- a/ui/widget/styles.css
+++ b/ui/widget/styles.css
@@ -16,6 +16,7 @@
 
 html, body {
   height: 100%;
+  
   /* Open Sans matches phila.gov typographic standard. System fonts as fallback. */
   font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 16px;

--- a/ui/widget/styles.css
+++ b/ui/widget/styles.css
@@ -1,4 +1,10 @@
-/* Reset & Base */
+/* Widget UI: styles.css
+   Embeddable property valuation history widget.
+   Styled to match Philadelphia city design standards (phila.gov / atlas.phila.gov).
+   Color Palette: navy #2C3968, orange #F2541B, gold #F2BC1B, warm grey #D8D7B1 */
+
+/* Reset and Base
+   Normalizes box model and removes browser default spacing. */
 
 *,
 *::before,
@@ -10,25 +16,28 @@
 
 html, body {
   height: 100%;
+  /* Open Sans matches phila.gov typographic standard. System fonts as fallback. */
   font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 16px;
   color: #232323;
-  background: #D8D7B1;
+  background: #D8D7B1; /* Warm grey page background mimics atlas.phila.gov framing. */
 }
 
 a {
-  color: #F2541B;
+  color: #F2541B; /* Philadelphia city brand orange. */
 }
 
 a:hover {
-  color: #c23d0e;
+  color: #c23d0e; /* Darker shade for sufficient contrast on hover. */
 }
 
 strong, b {
-  color: #F2541B;
+  color: #F2541B; /* Brand orange for emphasis. */
 }
 
-/* Widget Container */
+/* Widget Container
+   Centers widget on page with a max-width so it reads well on desktop.
+   White card surface sits on top of warm-grey body background. */
 
 .widget-container {
   max-width: 820px;
@@ -37,10 +46,12 @@ strong, b {
   border: 1px solid #cfcfcf;
 }
 
-/* OPA Lookup Bar */
+/* OPA Lookup Bar
+   Navy header bar where user enters an OPA account number.
+   Input and button are joined flush (gap: 0) to form a single search field. */
 
 .lookup-bar {
-  background: #2C3968;
+  background: #2C3968; /* Navy header matches phila.gov app bars. */
   color: #fff;
   padding: 16px 20px;
 }
@@ -54,11 +65,11 @@ strong, b {
 
 .lookup-input-group {
   display: flex;
-  gap: 0;
+  gap: 0; /* No gap between input and button. */
 }
 
 .lookup-input-group input {
-  flex: 1;
+  flex: 1; /* Input takes all available width, button stays its natural size. */
   padding: 8px 12px;
   font-size: 0.9rem;
   border: none;
@@ -75,7 +86,7 @@ strong, b {
   font-size: 0.9rem;
   font-weight: 600;
   font-family: inherit;
-  background: #F2BC1B;
+  background: #F2BC1B; /* Gold default state. */
   color: #232323;
   border: none;
   cursor: pointer;
@@ -83,11 +94,12 @@ strong, b {
 }
 
 .lookup-input-group button:hover {
-  background: #F2541B;
+  background: #F2541B; /* Shift to orange on hover. */
   color: #fff;
 }
 
-/* Valuation History Section */
+/* Valuation History Section
+   Main content area below lookup bar. */
 
 .valuation-history {
   padding: 20px;
@@ -97,11 +109,12 @@ strong, b {
   font-size: 1.1rem;
   font-weight: 700;
   color: #2C3968;
-  border-bottom: 2px solid #F2BC1B;
+  border-bottom: 2px solid #F2BC1B; /* Gold underline accent matches phila.gov section headers. */
   padding-bottom: 6px;
   margin-bottom: 12px;
 }
 
+/* Record count shown next to heading. Lighter weight to read as metadata. */
 .record-count {
   font-weight: 400;
   color: #888;
@@ -114,7 +127,10 @@ strong, b {
   margin-bottom: 20px;
 }
 
-/* Chart */
+/* Chart
+   Placeholder shown before charting library renders real chart.
+   Container min-height reserves space so layout doesn't shift
+   once a chart is injected. */
 
 .chart-wrapper {
   margin-bottom: 24px;
@@ -122,12 +138,13 @@ strong, b {
 
 .chart-container {
   width: 100%;
-  min-height: 200px;
+  min-height: 200px; /* Prevents layout shift when chart library loads. */
   border: 1px solid #e0e0e0;
   border-radius: 2px;
   position: relative;
 }
 
+/* Centered empty-state message. Hidden once a chart is rendered. */
 .chart-placeholder {
   display: flex;
   align-items: center;
@@ -142,37 +159,41 @@ strong, b {
   padding: 0 20px;
 }
 
-/* Data Table */
+/* Data Table
+   Tabular history of assessed values by year, populated dynamically from BigQuery.
+   overflow-x: Auto on wrapper lets table scroll horizontally on narrow screens
+   without breaking widget's fixed max-width. */
 
 .table-wrapper {
-  overflow-x: auto;
+  overflow-x: auto; /* Horizontal scroll for narrow viewports. */
 }
 
 .valuation-table {
   width: 100%;
-  border-collapse: collapse;
+  border-collapse: collapse; /* Remove default cell spacing. */
   font-size: 0.85rem;
 }
 
 .valuation-table thead th {
-  background: #2C3968;
+  background: #2C3968; /* Navy header row matches lookup bar. */
   color: #fff;
   font-weight: 600;
   text-align: left;
   padding: 10px 12px;
-  white-space: nowrap;
+  white-space: nowrap; /* Keep column headers on one line. */
 }
 
 .valuation-table tbody td {
   padding: 10px 12px;
   border-bottom: 1px solid #e0e0e0;
-  white-space: nowrap;
+  white-space: nowrap; /* Prevent dollar values from wrapping mid-number. */
 }
 
+/* Alternating row stripe for readability across many years. */
 .valuation-table tbody tr:nth-child(even) {
   background: #f4f3e8;
 }
 
 .valuation-table tbody tr:hover {
-  background: #D8D7B1;
+  background: #D8D7B1; /* Warm grey hover matches page background. */
 }

--- a/ui/widget/styles.css
+++ b/ui/widget/styles.css
@@ -210,7 +210,7 @@ strong, b {
 
 /* Tablet / Large Phone (≤ 768px)
    Reduce outer margin and padding. Table already scrolls horizontally. */
-@media (max-width: 768px) {
+@media (max-width <= 768px) {
   .widget-container {
     margin: 16px 12px; /* Reduce margins so widget uses more screen width. */
   }
@@ -241,7 +241,7 @@ strong, b {
 
 /* Small Phone (≤ 480px)
    Edge-to-edge layout. Larger touch targets. Reduced font sizes. */
-@media (max-width: 480px) {
+@media (max-width <= 480px) {
   .widget-container {
     margin: 0; /* Full-bleed on small phones. */
     border-left: none;
@@ -261,7 +261,7 @@ strong, b {
   }
 
   .lookup-bar {
-    padding: 14px 14px;
+    padding: 14px;
   }
 
   .valuation-history {


### PR DESCRIPTION
# Description

MapLibre GL JS map on assessment review page (reviewer folder) using CARTO Positron (final theme TBD) raster tiles as basemap. Map centered on Philadelphia at a city-wide zoom level.

Resolves #15 #16 #18 #19 

## Type of change

- [x] New feature
- [ ] Bug fix
- [x] Small fix/change
- [x] Documentation

## What should the reviewer know?

- MapLibre GL JS and its stylesheet are loaded from `unpkg.com` CDN (v5.5.0), so no npm install required.
- CARTO Positron was chosen as basemap (atm) as it's free (no API key), lightweight at city-wide zoom, and neutral enough to let assessment value choropleth layers stand out. Vector property tiles (issue #16) will be layered on top.
- To preview locally, open index.html directly in a browser.

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)