### PR TITLE
Issue 27 export assessment values geo json file

### DIFF
--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,12 @@ tasks/
 │   ├── main.py
 │   ├── requirements.txt
 │   └── tax_year_assessment_bins.sql
+|
+├── export_property_tile_info/   # Create a task to export a GeoJSON file of assesment values for each property. 
+|   ├── main.py 
+|   ├── requirements.txt
+|   └── property_tile_info.sql
+|
 ├── workflows/
 │   └── data_pipeline.yaml      # Orchestration workflow.
 ├── deploy.ps1                  # PowerShell deployment script.
@@ -221,6 +227,7 @@ gcloud functions deploy prepare-septa `
     --memory=512MB `
     --no-allow-unauthenticated
 
+
 # Load functions.
 gcloud functions deploy load-opa-properties `
     --gen2 `
@@ -304,6 +311,18 @@ gcloud functions deploy create-tax-year-assessment-bins `
     --timeout=1800s `
     --memory=512MB `
     --no-allow-unauthenticated
+
+gcloud functions deploy export_property_tile_info `
+    --gen2 `
+    --runtime=python311 `
+    --region=$REGION `
+    --source=tasks/export_property_tile_info `
+    --entry-point=export_property_tile_info `
+    --trigger-http `
+    --timeout=1800s `
+    --memory=4GB `
+    --no-allow-unauthenticated
+
 ```
 
 ## Workflow
@@ -349,6 +368,7 @@ gcloud functions call load-septa --region=us-east4
 # Derived functions.
 gcloud functions call create-training-data --region=us-east4
 gcloud functions call create-tax-year-assessment-bins --region=us-east4
+gcloud functions call export-property-tile-info --region=us-east4
 ```
 
 Scheduler:

--- a/tasks/deploy.ps1
+++ b/tasks/deploy.ps1
@@ -261,6 +261,20 @@ gcloud functions deploy create-tax-year-assessment-bins `
 
 Write-Host "Workflow" -ForegroundColor Green
 
+# Extract Property Tile Info.
+Write-Host "Deploying export-property-tile-info"
+gcloud functions deploy export-property-tile-info `
+    --gen2 `
+    --runtime=python311 `
+    --region=$REGION `
+    --source=tasks/export_property_tile_info `
+    --entry-point=export_property_tile_info `
+    --trigger-http `
+    --timeout=1800s `
+    --memory=4GB `
+    --no-allow-unauthenticated
+
+
 # Deploy the data pipeline workflow.
 Write-Host "Deploying data-pipeline workflow."
 gcloud workflows deploy data-pipeline `

--- a/tasks/export_property_tile_info/main.py
+++ b/tasks/export_property_tile_info/main.py
@@ -39,7 +39,7 @@ def export_property_tile_info(request):
         # Build GeoJSON FeatureCollection from query results.
         features = []
         for row in results:
-            geometry = json.loads(row.geometry_column)
+            geometry = json.loads(row.geometry)
             # Exclude the geometry column from properties to avoid duplication in the GeoJSON.
             # Once the columns are read into a dictionary, we can filter out the geometry column and use the rest as properties.
             properties = properties = {key: value for (key, value) in row.items() if key != "geometry_column"} 

--- a/tasks/export_property_tile_info/main.py
+++ b/tasks/export_property_tile_info/main.py
@@ -42,7 +42,7 @@ def export_property_tile_info(request):
             geometry = json.loads(row.geometry)
             # Exclude the geometry column from properties to avoid duplication in the GeoJSON.
             # Once the columns are read into a dictionary, we can filter out the geometry column and use the rest as properties.
-            properties = properties = {key: value for (key, value) in row.items() if key != "geometry_column"} 
+            properties = properties = {key: value for (key, value) in row.items() if key != "geometry_column"}
             feature = {
                 "type": "Feature",
                 "geometry": geometry,
@@ -70,5 +70,3 @@ def export_property_tile_info(request):
     except Exception as e:
         print(f"Error: {e}")
         return (f"Error exporting property tile info: {e}", 500)
-
-

--- a/tasks/export_property_tile_info/main.py
+++ b/tasks/export_property_tile_info/main.py
@@ -1,0 +1,74 @@
+
+"""
+HTTP Cloud Function to export property tile information from BigQuery to Cloud Storage.
+
+This function queries the BigQuery dataset for property tile information and exports the results as a GeoJSON
+file to a `musa5090s26-team5-temp_data` Cloud Storage bucket.
+
+Usage:
+    Deploy as a Cloud Function named "export-property-tile-info"
+"""
+
+
+import functions_framework
+import json
+from google.cloud import bigquery
+from google.cloud import storage
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+@functions_framework.http
+def export_property_tile_info(request):
+    try: 
+        temp_data_bucket = os.getenv("TEMP_DATA_BUCKET", "musa5090s26-team5-temp_data")
+
+        # Call the SQL file to get the property tile information.
+        with open("property_tile_info.sql", "r") as sql_file:
+            sql = sql_file.read()
+            print("Executing property_tile_info.sql...")
+
+        # Activate BigQuery client and run the query! 
+        client = bigquery.Client()
+
+        job = client.query(sql)
+        results = job.result()
+        print("Query executed successfully.")
+
+        # Build GeoJSON FeatureCollection from query results.
+        features = []
+        for row in results:
+            geometry = json.loads(row.geometry_column)
+            # Exclude the geometry column from properties to avoid duplication in the GeoJSON.
+            # Once the columns are read into a dictionary, we can filter out the geometry column and use the rest as properties.
+            properties = properties = {key: value for (key, value) in row.items() if key != "geometry_column"} 
+            feature = {
+                "type": "Feature",
+                "geometry": geometry,
+                "properties": properties
+            }
+            features.append(feature)
+
+        geojson = {
+            "type": "FeatureCollection",
+            "features": features,
+            }
+        print(f"Built FeatureCollection with {len(features)} features.")
+
+        storage_client = storage.Client()
+        bucket = storage_client.bucket(temp_data_bucket)
+        blob = bucket.blob("property_tile_info.geojson")
+        blob.upload_from_string(
+            json.dumps(geojson),
+            content_type="application/json",
+        )
+        print(f"Uploaded to gs://{temp_data_bucket}/property_tile_info.geojson")
+
+        return ("Successfully exported property tile info GeoJSON.", 200) 
+
+    except Exception as e:
+        print(f"Error: {e}")
+        return (f"Error exporting property tile info: {e}", 500)
+
+

--- a/tasks/export_property_tile_info/main.py
+++ b/tasks/export_property_tile_info/main.py
@@ -16,8 +16,8 @@ from google.cloud import bigquery
 from google.cloud import storage
 import os
 from dotenv import load_dotenv
+import pathlib
 
-load_dotenv()
 
 @functions_framework.http
 def export_property_tile_info(request):
@@ -25,9 +25,9 @@ def export_property_tile_info(request):
         temp_data_bucket = os.getenv("TEMP_DATA_BUCKET", "musa5090s26-team5-temp_data")
 
         # Call the SQL file to get the property tile information.
-        with open("property_tile_info.sql", "r") as sql_file:
-            sql = sql_file.read()
-            print("Executing property_tile_info.sql...")
+        DIR_NAME = pathlib.Path(__file__).parent
+        sql = (DIR_NAME / "property_tile_info.sql").read_text()
+        print("Executing property_tile_info.sql...")
 
         # Activate BigQuery client and run the query! 
         client = bigquery.Client()
@@ -42,7 +42,7 @@ def export_property_tile_info(request):
             geometry = json.loads(row.geometry)
             # Exclude the geometry column from properties to avoid duplication in the GeoJSON.
             # Once the columns are read into a dictionary, we can filter out the geometry column and use the rest as properties.
-            properties = properties = {key: value for (key, value) in row.items() if key != "geometry_column"}
+            properties =  {key: value for (key, value) in row.items() if key != "geometry"}
             feature = {
                 "type": "Feature",
                 "geometry": geometry,

--- a/tasks/export_property_tile_info/requirements.txt
+++ b/tasks/export_property_tile_info/requirements.txt
@@ -1,0 +1,4 @@
+functions-framework==3.*
+google-cloud-bigquery==3.*
+google-cloud-storage==2.*
+python-dotenv==1.*


### PR DESCRIPTION
# Description

Creates the `export-property-tile-info` Cloud Function that queries `derived.current_assessments` via a SQL file, converts the results into a GeoJSON FeatureCollection, and uploads it to the `team-temp_data` bucket as `property_tile_info.geojson`. This file is the prerequisite for issue #6 (vector tile generation).

Resolves #27

## Type of change
- [x] New feature

## What should the reviewer know?

- The function reads its query from `property_tile_info.sql` at runtime — **the SQL file is currently a placeholder** and will need to be filled in before the function can be successfully invoked. Once the SQL is written, the geometry column alias needs to match the `row.geometry` reference in `main.py`.
- The properties dict is built dynamically from all non-geometry columns returned by the query, so no Python changes are needed when SQL columns are added or removed: only the geometry column alias reference needs to be updated. (hopefully)
- Function is deployed with 4GB memory and a 1800s timeout to handle the geometry load.
- Added to `deploy.ps1` and `data_pipeline.yaml` after the derived tables step.

To deploy:

```powershell
.\deploy.ps1
```

To test once SQL is written:

```bash
gcloud functions call export-property-tile-info --region=us-east4
```

## Post-merge follow-ups
- [x] Actions required (specified below)
  - SQL author must complete `property_tile_info.sql` and confirm the geometry column alias name
  - Once SQL is finalized, update `row.geometry` in `main.py` to match the actual alias
  - Run `deploy.ps1` to deploy the function to GCP