### PR TITLE
Check issues 6, 8, and 27 functionality

### DIFF
--- a/tasks/current_assessment_bins/main.py
+++ b/tasks/current_assessment_bins/main.py
@@ -13,7 +13,6 @@ Use: Deploy as a Cloud Function named "create-current-assessment-bins"
 
 import functions_framework
 import pathlib
-import os
 from google.cloud import bigquery
 from dotenv import load_dotenv
 

--- a/tasks/deploy.ps1
+++ b/tasks/deploy.ps1
@@ -259,6 +259,19 @@ gcloud functions deploy create-tax-year-assessment-bins `
     --memory=512MB `
     --no-allow-unauthenticated
 
+# Current Assessment Bins (Issue #8).
+Write-Host "Deploying create-current-assessment-bins."
+gcloud functions deploy create-current-assessment-bins `
+    --gen2 `
+    --runtime=python311 `
+    --region=$REGION `
+    --source=tasks/current_assessment_bins `
+    --entry-point=create_current_assessment_bins `
+    --trigger-http `
+    --timeout=1800s `
+    --memory=512MB `
+    --no-allow-unauthenticated
+
 Write-Host "Workflow" -ForegroundColor Green
 
 # Extract Property Tile Info.

--- a/tasks/export_property_tile_info/main.py
+++ b/tasks/export_property_tile_info/main.py
@@ -69,4 +69,3 @@ def export_property_tile_info(request):
     except Exception as e:
         print(f"Error: {e}")
         return (f"Error exporting property tile info: {e}", 500)
-    

--- a/tasks/export_property_tile_info/main.py
+++ b/tasks/export_property_tile_info/main.py
@@ -15,13 +15,12 @@ import json
 from google.cloud import bigquery
 from google.cloud import storage
 import os
-from dotenv import load_dotenv
 import pathlib
 
 
 @functions_framework.http
 def export_property_tile_info(request):
-    try: 
+    try:
         temp_data_bucket = os.getenv("TEMP_DATA_BUCKET", "musa5090s26-team5-temp_data")
 
         # Call the SQL file to get the property tile information.
@@ -29,7 +28,7 @@ def export_property_tile_info(request):
         sql = (DIR_NAME / "property_tile_info.sql").read_text()
         print("Executing property_tile_info.sql...")
 
-        # Activate BigQuery client and run the query! 
+        # Activate BigQuery client and run the query!
         client = bigquery.Client()
 
         job = client.query(sql)
@@ -42,7 +41,7 @@ def export_property_tile_info(request):
             geometry = json.loads(row.geometry)
             # Exclude the geometry column from properties to avoid duplication in the GeoJSON.
             # Once the columns are read into a dictionary, we can filter out the geometry column and use the rest as properties.
-            properties =  {key: value for (key, value) in row.items() if key != "geometry"}
+            properties = {key: value for (key, value) in row.items() if key != "geometry"}
             feature = {
                 "type": "Feature",
                 "geometry": geometry,
@@ -65,8 +64,9 @@ def export_property_tile_info(request):
         )
         print(f"Uploaded to gs://{temp_data_bucket}/property_tile_info.geojson")
 
-        return ("Successfully exported property tile info GeoJSON.", 200) 
+        return ("Successfully exported property tile info GeoJSON.", 200)
 
     except Exception as e:
         print(f"Error: {e}")
         return (f"Error exporting property tile info: {e}", 500)
+    

--- a/tasks/export_property_tile_info/property_tile_info.sql
+++ b/tasks/export_property_tile_info/property_tile_info.sql
@@ -102,8 +102,8 @@ LEFT JOIN assessments_pivot AS ap
     ON p.parcel_number = ap.parcel_number
 LEFT JOIN `musa5090s26-team5.core.neighborhoods` AS n
     ON ST_WITHIN(
-        ST_GEOGFROMTEXT(ST_ASTEXT(p.geometry)),
-        ST_GEOGFROMTEXT(ST_ASTEXT(n.geometry))
+        p.geometry,
+        ST_GEOGFROMWKB(n.geometry)
     )
 WHERE
     p.category_code = '1'

--- a/tasks/generate_property_map_tiles/script.sh
+++ b/tasks/generate_property_map_tiles/script.sh
@@ -18,8 +18,10 @@ ogr2ogr \
   ./properties \
   ./property_tile_info.geojson
 
-  gcloud storage rm \
-  gs://musa5090s26-team5-public/tiles/properties
+gcloud storage rm \
+  --recursive \
+  gs://musa5090s26-team5-public/tiles/properties \
+  || true
 
 # Upload the vector tileset to the public bucket.
 gcloud storage cp \

--- a/tasks/workflows/data_pipeline.yaml
+++ b/tasks/workflows/data_pipeline.yaml
@@ -206,6 +206,17 @@ main:
                         timeout: 1800
                       result: export_property_tile_info_result
 
+            - create_current_assessment_bins:
+                steps:
+                  - run_create_current_assessment_bins:
+                      call: http.post
+                      args:
+                        url: ${base_url + "/create-current-assessment-bins"}
+                        auth:
+                          type: OIDC
+                        timeout: 1800
+                      result: create_current_assessment_bins_result
+
     - generate_property_map_tiles:
         steps:
           - run_generate_property_map_tiles:
@@ -215,7 +226,7 @@ main:
                 auth:
                   type: OAuth2
                 timeout: 1800
-              result: generate_property_map_  tiles_result
+              result: generate_property_map_tiles_result
 
     - return_success:
         return:
@@ -229,3 +240,6 @@ main:
             septa: "Completed"
             create_training_data: "Completed"
             tax_year_assessment_bins: "Completed"
+            current_assessment_bins: "Completed"
+            export_property_tile_info: "Completed"
+            generate_property_map_tiles: "Completed"


### PR DESCRIPTION
# Description

Audits and fixes integration issues introduced by merges for issues #6, #8, and #27. No new functionality added, all changes made to ensure three tasks deploy, run, and interoperate (hopefully) neatly.

- **data_pipeline.yaml**: Fixed a YAML-breaking space typo in the `generate_property_map_tiles` result variable name. Added `create-current-assessment-bins` (issue #8) as a parallel branch in the `run_derived_in_parallel` step, which was missing. Updated `return_success` to reflect all pipeline stages including `current_assessment_bins`, `export_property_tile_info`, and `generate_property_map_tiles`.
- **property_tile_info.sql**: Fixed neighborhood spatial join from `ST_GEOGFROMTEXT(ST_ASTEXT(n.geometry))` to `ST_GEOGFROMWKB(n.geometry)`, consistent with how create_training_data.sql handles same `core.neighborhoods` table.
- **script.sh**: Added `--recursive` to `gcloud storage rm` call and a `|| true` guard so first-run case (when tiles directory doesn't exist yet) doesn't abort job.
- **deploy.ps1**: Added missing `gcloud functions deploy` block for `create-current-assessment-bins`.

Resolves integration gaps for #6, #8, #27.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Small Fix/Change
- [ ] Documentation

## What should the reviewer know?

Each fix addresses something that caused a failure at runtime:

| File | What Broke | What Happened |
|---|---|---|
| data_pipeline.yaml | Space in `generate_property_map_  tiles_result`. | Workflow deploy fails with a YAML parse error w/ entire pipeline undeployable. |
| data_pipeline.yaml | `create-current-assessment-bins` missing from workflow. | Issue #8's Cloud Function would never be called by the pipeline, `derived.current_assessment_bins` would never be populated, breaking chart in reviewer UI. |
| property_tile_info.sql | `ST_GEOGFROMTEXT(ST_ASTEXT(n.geometry))` on WKB bytes. | BigQuery throws runtime error. `ST_ASTEXT` expects a GEOGRAPHY, but `core.neighborhoods.geometry` is stored as WKB BYTES from a non-geo Parquet load. `export-property-tile-info` would fail on every run with no neighborhood data. |
| script.sh | No `--recursive` on `gcloud storage rm`. | rm command fails silently or errors on any directory path, on first run it would also abort entire job since path doesn't exist yet, meaning tiles would never be uploaded to public bucket. |
| deploy.ps1 | `create-current-assessment-bins` not in deploy script. | Anyone running `deploy.ps1` would skip deploying issue #8 function without any error, function would be manually deployed or would silently be absent. |

## Post-Merge Follow-Ups

- [x] Actions required (specified below)

- [x] 1. Re-deploy data pipeline workflow to pick up YAML fix and new `create-current-assessment-bins` step.

- [x] 2. Deploy `create-current-assessment-bins` Cloud Function if not already done.

- [x] 3. Re-build and re-deploy `generate-property-map-tiles` Cloud Run job to pick up `script.sh` fix.