### PR TITLE
Issue 04 version2 real

### DIFF
--- a/tasks/README.md
+++ b/tasks/README.md
@@ -78,6 +78,10 @@ tasks/
 │   ├── main.py
 │   └── requirements.txt
 │
+│── generate_assessment_chart_config/ # Generate assessmemt chart config JSON for front-end. 
+│    ├──main.py
+│    └──requirements.txt
+│
 ├── workflows/
 │   └── data_pipeline.yaml      # Orchestration workflow.
 ├── deploy.ps1                  # PowerShell deployment script.

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,6 +73,11 @@ tasks/
 │   ├── main.py
 │   ├── requirements.txt
 │   └── tax_year_assessment_bins.sql
+│
+│── generate_tax_year_chart_config/  # Generate tax year chart config JSON for front-end.
+│   ├── main.py
+│   └── requirements.txt
+│
 ├── workflows/
 │   └── data_pipeline.yaml      # Orchestration workflow.
 ├── deploy.ps1                  # PowerShell deployment script.
@@ -304,6 +309,17 @@ gcloud functions deploy create-tax-year-assessment-bins `
     --timeout=1800s `
     --memory=512MB `
     --no-allow-unauthenticated
+
+gcloud functions deploy generate-tax-year-chart-config `
+    --gen2 `
+    --runtime=python311 `
+    --region=$REGION `
+    --source=tasks/generate_tax_year_chart_config `
+    --entry-point=generate_tax_year_chart_config `
+    --trigger-http `
+    --timeout=1800s `
+    --memory=512MB `
+    --no-allow-unauthenticated
 ```
 
 ## Workflow
@@ -349,6 +365,7 @@ gcloud functions call load-septa --region=us-east4
 # Derived functions.
 gcloud functions call create-training-data --region=us-east4
 gcloud functions call create-tax-year-assessment-bins --region=us-east4
+gcloud functions call generate-tax-year-chart-config --region=us-east4
 ```
 
 Scheduler:

--- a/tasks/deploy.ps1
+++ b/tasks/deploy.ps1
@@ -259,6 +259,20 @@ gcloud functions deploy create-tax-year-assessment-bins `
     --memory=512MB `
     --no-allow-unauthenticated
 
+# Assessment Chart Config.
+Write-Host "Deploying generate-assessment-chart-configs."
+gcloud functions deploy generate-assessment-chart-configs `
+    --gen2 `
+    --runtime=python311 `
+    --region=$REGION `
+    --source=tasks/generate_assessment_chart_configs `
+    --entry-point=generate_assessment_chart_config `
+    --trigger-http `
+    --timeout=1800s `
+    --memory=512MB `
+    --no-allow-unauthenticated
+
+
 Write-Host "Workflow" -ForegroundColor Green
 
 # Deploy the data pipeline workflow.

--- a/tasks/deploy.ps1
+++ b/tasks/deploy.ps1
@@ -272,6 +272,19 @@ gcloud functions deploy generate-assessment-chart-configs `
     --memory=512MB `
     --no-allow-unauthenticated
 
+# Tax Year Chart Config.
+Write-Host " Deploying generate-tax-year-chart-config."
+gcloud functions deploy generate-tax-year-chart-config `
+    --gen2 `
+    --runtime=python311 `
+    --region=$REGION `
+    --source=tasks/generate_tax_year_chart_config `
+    --entry-point=generate_tax_year_chart_config `
+    --trigger-http `
+    --timeout=1800s `
+    --memory=512MB `
+    --no-allow-unauthenticated
+
 
 Write-Host "Workflow" -ForegroundColor Green
 

--- a/tasks/generate_assessment_chart_configs/main.py
+++ b/tasks/generate_assessment_chart_configs/main.py
@@ -1,0 +1,68 @@
+"""
+HTTP Cloud Function to generate tax year chart config from BigQuery to Cloud Storage.
+
+This function queries derived.current_assessment_bins for the most recent tax year
+and exports the results as a JSON file to the public Cloud Storage bucket.
+
+Usage:
+    Deploy as a Cloud Function named "generate-tax-assessment-chart-configs"
+"""
+import functions_framework
+import json
+from google.cloud import bigquery
+from google.cloud import storage
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+SQL_QUERY = """
+    SELECT
+        lower_bound,
+        upper_bound,
+        property_count,
+        tax_year
+    FROM `derived.current_assessment_bins`
+    WHERE tax_year = (SELECT MAX(tax_year) FROM `derived.current_assessment_bins`)
+    ORDER BY lower_bound
+"""
+
+@functions_framework.http
+def generate_assessment_chart_configs(request):
+    try:
+        public_bucket = os.getenv("PUBLIC_BUCKET", "musa5090s26-team5")
+
+        # Initialize BigQuery client and run query.
+        bq_client = bigquery.Client()
+        job = bq_client.query(SQL_QUERY)
+        results = job.result()
+        print("Query executed successfully.")
+
+        # Process results into a list of dictionaries.
+        chart_config = [
+            {
+                "lower_bound": row.lower_bound,
+                "upper_bound": row.upper_bound,
+                "property_count": row.property_count,
+                "tax_year": row.tax_year,
+            }
+            for row in results
+        ]
+        print(f"Built JSON chart config with {len(chart_config)} entries.")
+
+        # Upload to public Cloud Storage bucket.
+        storage_client = storage.Client()
+        bucket = storage_client.bucket(public_bucket)
+        blob = bucket.blob("configs/current_assessment_bins.json")
+        blob.upload_from_string(
+            json.dumps(chart_config),
+            content_type="application/json",
+        )
+        blob.make_public()
+        print(f"Uploaded to gs://{public_bucket}/configs/current_assessment_bins.json")
+
+        return ("Assessment chart config generated and uploaded successfully.", 200)
+
+    except Exception as e:
+        print(f"Error generating assessment chart config: {e}")
+        return (f"Error generating assessment chart config: {e}", 500)

--- a/tasks/generate_assessment_chart_configs/main.py
+++ b/tasks/generate_assessment_chart_configs/main.py
@@ -64,4 +64,3 @@ def generate_assessment_chart_configs(request):
     except Exception as e:
         print(f"Error generating assessment chart config: {e}")
         return (f"Error generating assessment chart config: {e}", 500)
-        

--- a/tasks/generate_assessment_chart_configs/main.py
+++ b/tasks/generate_assessment_chart_configs/main.py
@@ -12,9 +12,6 @@ import json
 from google.cloud import bigquery
 from google.cloud import storage
 import os
-from dotenv import load_dotenv
-
-load_dotenv()
 
 SQL_QUERY = """
     SELECT

--- a/tasks/generate_assessment_chart_configs/main.py
+++ b/tasks/generate_assessment_chart_configs/main.py
@@ -53,7 +53,7 @@ def generate_assessment_chart_configs(request):
             json.dumps(chart_config),
             content_type="application/json",
         )
-        
+
         print(f"Uploaded to gs://{public_bucket}/configs/current_assessment_bins.json")
 
         return ("Assessment chart config generated and uploaded successfully.", 200)

--- a/tasks/generate_assessment_chart_configs/main.py
+++ b/tasks/generate_assessment_chart_configs/main.py
@@ -24,6 +24,7 @@ SQL_QUERY = """
     ORDER BY lower_bound
 """
 
+
 @functions_framework.http
 def generate_assessment_chart_configs(request):
     try:
@@ -63,3 +64,4 @@ def generate_assessment_chart_configs(request):
     except Exception as e:
         print(f"Error generating assessment chart config: {e}")
         return (f"Error generating assessment chart config: {e}", 500)
+        

--- a/tasks/generate_assessment_chart_configs/main.py
+++ b/tasks/generate_assessment_chart_configs/main.py
@@ -5,7 +5,7 @@ This function queries derived.current_assessment_bins for the most recent tax ye
 and exports the results as a JSON file to the public Cloud Storage bucket.
 
 Usage:
-    Deploy as a Cloud Function named "generate-tax-assessment-chart-configs"
+    Deploy as a Cloud Function named "generate-assessment-chart-config"
 """
 import functions_framework
 import json
@@ -18,9 +18,7 @@ SQL_QUERY = """
         lower_bound,
         upper_bound,
         property_count,
-        tax_year
     FROM `derived.current_assessment_bins`
-    WHERE tax_year = (SELECT MAX(tax_year) FROM `derived.current_assessment_bins`)
     ORDER BY lower_bound
 """
 
@@ -28,7 +26,7 @@ SQL_QUERY = """
 @functions_framework.http
 def generate_assessment_chart_configs(request):
     try:
-        public_bucket = os.getenv("PUBLIC_BUCKET", "musa5090s26-team5")
+        public_bucket = os.getenv("PUBLIC_BUCKET", "musa5090s26-team5-public")
 
         # Initialize BigQuery client and run query.
         bq_client = bigquery.Client()
@@ -41,8 +39,7 @@ def generate_assessment_chart_configs(request):
             {
                 "lower_bound": row.lower_bound,
                 "upper_bound": row.upper_bound,
-                "property_count": row.property_count,
-                "tax_year": row.tax_year,
+                "property_count": row.property_count
             }
             for row in results
         ]
@@ -56,7 +53,7 @@ def generate_assessment_chart_configs(request):
             json.dumps(chart_config),
             content_type="application/json",
         )
-        blob.make_public()
+        
         print(f"Uploaded to gs://{public_bucket}/configs/current_assessment_bins.json")
 
         return ("Assessment chart config generated and uploaded successfully.", 200)

--- a/tasks/generate_assessment_chart_configs/requirements.txt
+++ b/tasks/generate_assessment_chart_configs/requirements.txt
@@ -1,4 +1,3 @@
 functions-framework==3.*
 google-cloud-bigquery==3.*
-python-dotenv==1.*
 google-cloud-storage==2.*

--- a/tasks/generate_assessment_chart_configs/requirements.txt
+++ b/tasks/generate_assessment_chart_configs/requirements.txt
@@ -1,0 +1,4 @@
+functions-framework==3.*
+google-cloud-bigquery==3.*
+python-dotenv==1.*
+google-cloud-storage==2.*

--- a/tasks/generate_tax_year_chart_config/main.py
+++ b/tasks/generate_tax_year_chart_config/main.py
@@ -20,7 +20,8 @@ SQL_QUERY = """
     SELECT
         lower_bound,
         upper_bound,
-        property_count
+        property_count,
+        tax_year
     FROM `derived.tax_year_assessment_bins`
     WHERE tax_year = (SELECT MAX(tax_year) FROM `derived.tax_year_assessment_bins`)
     ORDER BY lower_bound
@@ -43,6 +44,7 @@ def generate_tax_year_chart_config(request):
                 "lower_bound": row.lower_bound,
                 "upper_bound": row.upper_bound,
                 "property_count": row.property_count,
+                "tax_year": row.tax_year,
             }
             for row in results
         ]

--- a/tasks/generate_tax_year_chart_config/main.py
+++ b/tasks/generate_tax_year_chart_config/main.py
@@ -11,10 +11,9 @@ import functions_framework
 import json
 from google.cloud import bigquery
 from google.cloud import storage
-import os
-from dotenv import load_dotenv
 
-load_dotenv()
+
+
 
 SQL_QUERY = """
     SELECT

--- a/tasks/generate_tax_year_chart_config/main.py
+++ b/tasks/generate_tax_year_chart_config/main.py
@@ -11,6 +11,7 @@ import functions_framework
 import json
 from google.cloud import bigquery
 from google.cloud import storage
+import os
 
 SQL_QUERY = """
     SELECT
@@ -27,7 +28,7 @@ SQL_QUERY = """
 @functions_framework.http
 def generate_tax_year_chart_config(request):
     try:
-        public_bucket = os.getenv("PUBLIC_BUCKET", "musa5090s26-team5")
+        public_bucket = os.getenv("PUBLIC_BUCKET", "musa5090s26-team5-public")
 
         # Initialize BigQuery client and run query.
         bq_client = bigquery.Client()
@@ -55,7 +56,6 @@ def generate_tax_year_chart_config(request):
             json.dumps(chart_config),
             content_type="application/json",
         )
-        blob.make_public()
         print(f"Uploaded to gs://{public_bucket}/configs/tax_year_assessment_bins.json")
 
         return ("Tax year chart config generated and uploaded successfully.", 200)

--- a/tasks/generate_tax_year_chart_config/main.py
+++ b/tasks/generate_tax_year_chart_config/main.py
@@ -63,4 +63,3 @@ def generate_tax_year_chart_config(request):
     except Exception as e:
         print(f"Error generating tax year chart config: {e}")
         return (f"Error generating tax year chart config: {e}", 500)
-        

--- a/tasks/generate_tax_year_chart_config/main.py
+++ b/tasks/generate_tax_year_chart_config/main.py
@@ -12,9 +12,6 @@ import json
 from google.cloud import bigquery
 from google.cloud import storage
 
-
-
-
 SQL_QUERY = """
     SELECT
         lower_bound,
@@ -25,6 +22,7 @@ SQL_QUERY = """
     WHERE tax_year = (SELECT MAX(tax_year) FROM `derived.tax_year_assessment_bins`)
     ORDER BY lower_bound
 """
+
 
 @functions_framework.http
 def generate_tax_year_chart_config(request):
@@ -65,3 +63,4 @@ def generate_tax_year_chart_config(request):
     except Exception as e:
         print(f"Error generating tax year chart config: {e}")
         return (f"Error generating tax year chart config: {e}", 500)
+        

--- a/tasks/generate_tax_year_chart_config/main.py
+++ b/tasks/generate_tax_year_chart_config/main.py
@@ -1,0 +1,66 @@
+"""
+HTTP Cloud Function to generate tax year chart config from BigQuery to Cloud Storage.
+
+This function queries derived.tax_year_assessment_bins for the most recent tax year
+and exports the results as a JSON file to the public Cloud Storage bucket.
+
+Usage:
+    Deploy as a Cloud Function named "generate-tax-year-chart-config"
+"""
+import functions_framework
+import json
+from google.cloud import bigquery
+from google.cloud import storage
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+SQL_QUERY = """
+    SELECT
+        lower_bound,
+        upper_bound,
+        property_count
+    FROM `derived.tax_year_assessment_bins`
+    WHERE tax_year = (SELECT MAX(tax_year) FROM `derived.tax_year_assessment_bins`)
+    ORDER BY lower_bound
+"""
+
+@functions_framework.http
+def generate_tax_year_chart_config(request):
+    try:
+        public_bucket = os.getenv("PUBLIC_BUCKET", "musa5090s26-team5")
+
+        # Initialize BigQuery client and run query.
+        bq_client = bigquery.Client()
+        job = bq_client.query(SQL_QUERY)
+        results = job.result()
+        print("Query executed successfully.")
+
+        # Process results into a list of dictionaries.
+        chart_config = [
+            {
+                "lower_bound": row.lower_bound,
+                "upper_bound": row.upper_bound,
+                "property_count": row.property_count,
+            }
+            for row in results
+        ]
+        print(f"Built JSON chart config with {len(chart_config)} entries.")
+
+        # Upload to public Cloud Storage bucket.
+        storage_client = storage.Client()
+        bucket = storage_client.bucket(public_bucket)
+        blob = bucket.blob("configs/tax_year_assessment_bins.json")
+        blob.upload_from_string(
+            json.dumps(chart_config),
+            content_type="application/json",
+        )
+        blob.make_public()
+        print(f"Uploaded to gs://{public_bucket}/configs/tax_year_assessment_bins.json")
+
+        return ("Tax year chart config generated and uploaded successfully.", 200)
+
+    except Exception as e:
+        print(f"Error generating tax year chart config: {e}")
+        return (f"Error generating tax year chart config: {e}", 500)

--- a/tasks/generate_tax_year_chart_config/requirements.txt
+++ b/tasks/generate_tax_year_chart_config/requirements.txt
@@ -1,4 +1,3 @@
 functions-framework==3.*
 google-cloud-bigquery==3.*
-python-dotenv==1.*
 google-cloud-storage==2.*

--- a/tasks/generate_tax_year_chart_config/requirements.txt
+++ b/tasks/generate_tax_year_chart_config/requirements.txt
@@ -1,0 +1,4 @@
+functions-framework==3.*
+google-cloud-bigquery==3.*
+python-dotenv==1.*
+google-cloud-storage==2.*

--- a/tasks/workflows/data_pipeline.yaml
+++ b/tasks/workflows/data_pipeline.yaml
@@ -206,6 +206,17 @@ main:
                         timeout: 1800
                       result: generate_tax_year_chart_config_result
 
+            - generate_tax_assessment_chart_configs:
+                steps:
+                  - run_generate_tax_assessment_chart_configs:
+                      call: http.post
+                      args:
+                        url: ${base_url + "/generate-tax-assessment-chart-configs"}
+                        auth:
+                          type: OIDC
+                        timeout: 1800
+                      result: generate_tax_assessment_chart_configs_result
+
     - return_success:
         return:
           status: "SUCCESS"

--- a/tasks/workflows/data_pipeline.yaml
+++ b/tasks/workflows/data_pipeline.yaml
@@ -194,6 +194,17 @@ main:
                           type: OIDC
                         timeout: 1800
                       result: create_tax_year_assessment_bins_result
+                    
+            - generate_tax_year_chart_config:
+                steps:
+                  - run_generate_tax_year_chart_config:
+                      call: http.post
+                      args:
+                        url: ${base_url + "/generate-tax-year-chart-config"}
+                        auth:
+                          type: OIDC
+                        timeout: 1800
+                      result: generate_tax_year_chart_config_result
 
     - return_success:
         return:


### PR DESCRIPTION
# Description

Adds two Cloud Functions to generate JSON chart config files from BigQuery for use by the front end for assessment chart configs and tax year chart configs.

Resolves #4, #5

## Type of change
- [x] New feature

## What should the reviewer know?

Two new Cloud Functions under `tasks/`:
- `generate_tax_year_chart_config` — queries `derived.tax_year_assessment_bins` for the most recent tax year and writes to `gs://musa5090s26-team5-public/configs/tax_year_assessment_bins.json`
- `generate_assessment_chart_configs` — queries `derived.current_assessment_bins` for the most recent tax year and writes to `gs://musa5090s26-team5-public/configs/current_assessment_bins.json`

Note: Cannot run locally due to `gcloud` auth issues and Poetry not being installable on this machine. Please deploy using the commands added to `deploy.ps1` after merging.

## Post-merge follow-ups

- [x] Actions required (specified below)

Reviewer please run the relevant deploy blocks from `deploy.ps1` to deploy both functions to GCP after merging.
Sorry that my `gcloud` and linter mechanics are wonky. If there are issues, I will try and correct on my Windows system instead of WSL, perhaps the linters work there. 

Don't hesitate to reach out regarding errors. Looking to do the rest of the scripting fixes 4/24 