### PR TITLE
issue-20 Export a JSON file with map styling metadata

### DIFF
--- a/tasks/README.md
+++ b/tasks/README.md
@@ -79,6 +79,10 @@ tasks/
 |   ├── requirements.txt
 |   └── property_tile_info.sql
 |
+├── generate_map_styling_metadata/   # Create a task to export a GeoJSON file map styling metadata. 
+|   ├── main.py 
+|   └── requirements.txt
+|
 ├── workflows/
 │   └── data_pipeline.yaml      # Orchestration workflow.
 ├── deploy.ps1                  # PowerShell deployment script.
@@ -312,7 +316,7 @@ gcloud functions deploy create-tax-year-assessment-bins `
     --memory=512MB `
     --no-allow-unauthenticated
 
-gcloud functions deploy export_property_tile_info `
+gcloud functions deploy export-property-tile-info `
     --gen2 `
     --runtime=python311 `
     --region=$REGION `
@@ -321,6 +325,17 @@ gcloud functions deploy export_property_tile_info `
     --trigger-http `
     --timeout=1800s `
     --memory=4GB `
+    --no-allow-unauthenticated
+
+gcloud functions deploy generate-map-styling-metadata `
+    --gen2 `
+    --runtime=python311 `
+    --region=$REGION `
+    --source=tasks/generate-map-styling-metadata `
+    --entry-point=generate-map-styling-metadata `
+    --trigger-http `
+    --timeout=1800s `
+    --memory=512MB `
     --no-allow-unauthenticated
 
 ```

--- a/tasks/deploy.ps1
+++ b/tasks/deploy.ps1
@@ -295,6 +295,19 @@ gcloud builds submit tasks/generate_property_map_tiles `
 gcloud run jobs deploy generate-property-map-tiles `  
 --image=$REGION-docker.pkg.dev/$PROJECT_ID/cama/generate-property-map-tiles `  
 --region=$REGION
+
+# Export map styling metadata.
+Write-Host "Deploying generate-map-styling-metadata"
+gcloud functions deploy generate-map-styling-metadata `
+    --gen2 `
+    --runtime=python311 `
+    --region=$REGION `
+    --source=tasks/generate_map_styling_metadata `
+    --entry-point=generate_map_styling_metadata `
+    --trigger-http `
+    --timeout=1800s `
+    --memory=512MB `
+    --no-allow-unauthenticated
     
 
 # Deploy the data pipeline workflow.

--- a/tasks/generate_map_styling_metadata/main.py
+++ b/tasks/generate_map_styling_metadata/main.py
@@ -18,17 +18,17 @@ import os
 SQL_QUERY = """
     WITH predicted AS (
         SELECT
-            MIN(predicted_value) AS min,
-            MAX(predicted_value) AS max,
-            APPROX_QUANTILES(predicted_value, 4) AS breakpoints)
+            MIN(predicted_value) AS predicted_min,
+            MAX(predicted_value) AS predicted_max,
+            APPROX_QUANTILES(predicted_value, 4) AS predicted_breakpoints)
         FROM `derived.current_assessments`
         WHERE predicted_value IS NOT NULL AND predicted_value >0
     ),
     tax_year AS (
         SELECT
-            MIN(market_value) AS min,
-            MAX(market_value) AS max,
-            APPROX_QUANTILES(market_value, 4) AS breakpoints
+            MIN(market_value) AS tax_year_min,
+            MAX(market_value) AS tax_year_max,
+            APPROX_QUANTILES(market_value, 4) AS tax_year_breakpoints
         FROM `core.opa_assessments`
         WHERE market_value IS NOT NULL AND market_value >0
             AND year = (SELECT MAX(year) FROM `core.opa_assessments`)
@@ -52,17 +52,18 @@ def export_map_styling(request):
         styling_metadata = {}
         for row in results:
             styling_metadata = {
-                "sale_price": {
-                    "min": row.min,
-                    "max": row.max,
-                    "breakpoints": list(row.breakpoints)
+                "predicted_value": {
+                    "min": row.predicted_min,
+                    "max": row.predicted_max,
+                    "breakpoints": list(row.predicted_breakpoints)
                 },
-                "year_built": {
-                    "min": row.year_built_min,
-                    "max": row.year_built_max,
-                    "breakpoints": list(row.year_built_breakpoints)
+                "market_value" : {
+                    "min": row.tax_year_min,
+                    "max": row.tax_year_max,
+                    "breakpoints": list(row.tax_year_breakpoints)
                 }
             }
+                
             print(f"Processed row: { styling_metadata}")
 
         # Upload to public GCS bucket.

--- a/tasks/generate_map_styling_metadata/main.py
+++ b/tasks/generate_map_styling_metadata/main.py
@@ -1,0 +1,75 @@
+"""
+HTTP Cloud Function to export map styling metadata to Cloud Storage.
+
+This function is meant to query derived.current_assessments_model_training_data 
+and export the relevant map styling metadata to the public GCS bucket.
+
+Usage:
+    Deploy as a Cloud Function named "generate-map-styling-metadata"
+"""
+
+import functions_framework
+import json
+from google.cloud import bigquery
+from google.cloud import storage
+import os
+
+# year_built is commented out for now, in case we want to add it later.
+SQL_QUERY = """
+    SELECT 
+        MIN(sale_price) AS min,
+        MAX(sale_price) AS max,
+        APPROX_QUANTILES(sale_price, 4) AS breakpoints,
+        MIN(year_built) AS year_built_min,
+        MAX(year_built) AS year_built_max,
+        APPROX_QUANTILES(year_built, 4) AS year_built_breakpoints
+    FROM `derived.current_assessments_model_training_data`
+"""
+
+@functions_framework.http
+def export_map_styling(request):
+    try:
+        public_bucket = os.getenv("PUBLIC_BUCKET", "musa5090s26-team5")
+
+        # Initialize BQ client and execute
+        bq_client = bigquery.Client()
+        job = bq_client.query(SQL_QUERY)
+        results = job.result()
+        print("Executed SQL query to get map styling metadata.")
+
+        # Process results into a dictionary.   
+
+        styling_metadata = {}
+        for row in results:
+            styling_metadata = {
+                "sale_price": {
+                    "min": row.min,    
+                    "max": row.max,
+                    "breakpoints": list(row.breakpoints)
+                },
+                "year_built": {
+                    "min": row.year_built_min,
+                    "max": row.year_built_max,
+                    "breakpoints": list(row.year_built_breakpoints)
+                }
+            }
+            print(f"Processed row: { styling_metadata}")
+
+        #Upload to public GCS bucket
+        storage_client = storage.Client()
+        bucket = storage_client.bucket(public_bucket)
+        blob = bucket.blob("configs/map_styling_metadata.json")
+        blob.upload_from_string(
+            json.dumps(styling_metadata),
+            content_type="application/json"
+        )
+
+        blob.make_public()
+        print(f"Uploaded to gs://{public_bucket}/configs/map_styling_metadata.json")
+
+        return ("Successfully exported map styling metadata.", 200)
+    
+    except Exception as e:
+        print(f"Error exporting map styling metadata: {e}.")
+        return (f"Error: {e}.", 500)
+

--- a/tasks/generate_map_styling_metadata/main.py
+++ b/tasks/generate_map_styling_metadata/main.py
@@ -57,13 +57,12 @@ def export_map_styling(request):
                     "max": row.predicted_max,
                     "breakpoints": list(row.predicted_breakpoints)
                 },
-                "market_value" : {
+                "market_value": {
                     "min": row.tax_year_min,
                     "max": row.tax_year_max,
                     "breakpoints": list(row.tax_year_breakpoints)
                 }
-            }
-                
+            } 
             print(f"Processed row: { styling_metadata}")
 
         # Upload to public GCS bucket.

--- a/tasks/generate_map_styling_metadata/main.py
+++ b/tasks/generate_map_styling_metadata/main.py
@@ -1,7 +1,7 @@
 """
 HTTP Cloud Function to export map styling metadata to Cloud Storage.
 
-This function is meant to query derived.current_assessments_model_training_data 
+This function is meant to query derived.current_assessments_model_training_data
 and export the relevant map styling metadata to the public GCS bucket.
 
 Usage:
@@ -16,7 +16,7 @@ import os
 
 # year_built is commented out for now, in case we want to add it later.
 SQL_QUERY = """
-    SELECT 
+    SELECT
         MIN(sale_price) AS min,
         MAX(sale_price) AS max,
         APPROX_QUANTILES(sale_price, 4) AS breakpoints,
@@ -25,6 +25,7 @@ SQL_QUERY = """
         APPROX_QUANTILES(year_built, 4) AS year_built_breakpoints
     FROM `derived.current_assessments_model_training_data`
 """
+
 
 @functions_framework.http
 def export_map_styling(request):
@@ -37,8 +38,7 @@ def export_map_styling(request):
         results = job.result()
         print("Executed SQL query to get map styling metadata.")
 
-        # Process results into a dictionary.   
-
+        # Process results into a dictionary.
         styling_metadata = {}
         for row in results:
             styling_metadata = {
@@ -55,7 +55,7 @@ def export_map_styling(request):
             }
             print(f"Processed row: { styling_metadata}")
 
-        #Upload to public GCS bucket
+        # Upload to public GCS bucket.
         storage_client = storage.Client()
         bucket = storage_client.bucket(public_bucket)
         blob = bucket.blob("configs/map_styling_metadata.json")
@@ -68,8 +68,7 @@ def export_map_styling(request):
         print(f"Uploaded to gs://{public_bucket}/configs/map_styling_metadata.json")
 
         return ("Successfully exported map styling metadata.", 200)
-    
+
     except Exception as e:
         print(f"Error exporting map styling metadata: {e}.")
         return (f"Error: {e}.", 500)
-

--- a/tasks/generate_map_styling_metadata/main.py
+++ b/tasks/generate_map_styling_metadata/main.py
@@ -43,7 +43,7 @@ def export_map_styling(request):
         for row in results:
             styling_metadata = {
                 "sale_price": {
-                    "min": row.min,    
+                    "min": row.min,
                     "max": row.max,
                     "breakpoints": list(row.breakpoints)
                 },

--- a/tasks/generate_map_styling_metadata/main.py
+++ b/tasks/generate_map_styling_metadata/main.py
@@ -16,21 +16,31 @@ import os
 
 # year_built is commented out for now, in case we want to add it later.
 SQL_QUERY = """
-    SELECT
-        MIN(sale_price) AS min,
-        MAX(sale_price) AS max,
-        APPROX_QUANTILES(sale_price, 4) AS breakpoints,
-        MIN(year_built) AS year_built_min,
-        MAX(year_built) AS year_built_max,
-        APPROX_QUANTILES(year_built, 4) AS year_built_breakpoints
-    FROM `derived.current_assessments_model_training_data`
+    WITH predicted AS (
+        SELECT
+            MIN(predicted_value) AS min,
+            MAX(predicted_value) AS max,
+            APPROX_QUANTILES(predicted_value, 4) AS breakpoints)
+        FROM `derived.current_assessments`
+        WHERE predicted_value IS NOT NULL AND predicted_value >0
+    ),
+    tax_year AS (
+        SELECT
+            MIN(market_value) AS min,
+            MAX(market_value) AS max,
+            APPROX_QUANTILES(market_value, 4) AS breakpoints
+        FROM `core.opa_assessments`
+        WHERE market_value IS NOT NULL AND market_value >0
+            AND year = (SELECT MAX(year) FROM `core.opa_assessments`)
+    )
+    SELECT * FROM predicted, tax_year
 """
 
 
 @functions_framework.http
 def export_map_styling(request):
     try:
-        public_bucket = os.getenv("PUBLIC_BUCKET", "musa5090s26-team5")
+        public_bucket = os.getenv("PUBLIC_BUCKET", "musa5090s26-team5-public")
 
         # Initialize BQ client and execute
         bq_client = bigquery.Client()
@@ -64,7 +74,6 @@ def export_map_styling(request):
             content_type="application/json"
         )
 
-        blob.make_public()
         print(f"Uploaded to gs://{public_bucket}/configs/map_styling_metadata.json")
 
         return ("Successfully exported map styling metadata.", 200)

--- a/tasks/generate_map_styling_metadata/main.py
+++ b/tasks/generate_map_styling_metadata/main.py
@@ -62,7 +62,7 @@ def export_map_styling(request):
                     "max": row.tax_year_max,
                     "breakpoints": list(row.tax_year_breakpoints)
                 }
-            } 
+            }
             print(f"Processed row: { styling_metadata}")
 
         # Upload to public GCS bucket.

--- a/tasks/generate_map_styling_metadata/requirements.txt
+++ b/tasks/generate_map_styling_metadata/requirements.txt
@@ -1,0 +1,3 @@
+functions-framework==3.*
+google-cloud-bigquery==3.*
+google-cloud-storage==2.*

--- a/tasks/workflows/data_pipeline.yaml
+++ b/tasks/workflows/data_pipeline.yaml
@@ -184,6 +184,17 @@ main:
                         timeout: 1800
                       result: create_training_data_result
 
+            - generate_map_styling_metadata:
+                steps:
+                  - run_generate_map_stlying_metadata:
+                      call: http.post
+                      args:
+                        url: ${base_url + "/generate-map-styling-metadata"}
+                        auth:
+                          type: OIDC
+                        timeout: 1800
+                      result: generate_map_styling_metadata_result
+
             - create_tax_year_assessment_bins:
                 steps:
                   - run_create_tax_year_assessment_bins:
@@ -239,6 +250,7 @@ main:
                         timeout: 1800
                       result: create_current_assessment_bins_result
 
+       
     - generate_property_map_tiles:
         steps:
           - run_generate_property_map_tiles:


### PR DESCRIPTION
# Description

A Cloud Function that queries `derived.current_assessments_model_training_data` to compute `min`, `max`, and `quartile breakpoints` for `sale_price` and `year_built`, and exports the results as a JSON file (`configs/map_styling_metadata.json`) to the public GCS bucket. This metadata is intended to support styling of choropleth map layers on the front-end.

 @tess-vu  — please flag if `current_assessments_model_training_data` is the wrong source table. I am happy to fix it. 

Resolves #\[20\]

## Type of change

- [X] New feature
- [X] Documentation

## What should the reviewer know?

This PR adds a new Cloud Function generate-map-styling-metadata that queries `derived.current_assessments_model_training_data` in BigQuery to compute `min`, `max`, and quartile `breakpoints` for `sale_price` and `year_built`, and uploads the result as configs/map_styling_metadata.json to the public GCS bucket.

The `deploy.ps1` was updated to reflect this issue's addition. 

Furthermore, I noticed an error I made for `gcloud functions deploy export-property-tile-info` naming scheme, so I fixed that, which you can see in the changes section. 

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a `gcloud` command to upload to GCP)._

- [X] Actions required:
Run the deploy command above to deploy the Cloud Function to GCP.

`gcloud functions deploy generate-map-styling-metadata ` still needs to be ran. I apologize for my inability to test it. 
