### PR TITLE
Add reviewer assessment dashboard UI

### DIFF
--- a/ui/reviewer/index.html
+++ b/ui/reviewer/index.html
@@ -34,6 +34,10 @@
            Driven by current_assessment_bins.json (issue #5/#19). -->
       <section class="chart-section">
         <h2>Predicted Assessment Value Distribution</h2>
+        <div class="chart-year-filter">
+          <label for="current-year-select">Year:</label>
+          <select id="current-year-select"></select>
+        </div>
         <div class="chart-container" id="current-assessment-chart"></div>
       </section>
 
@@ -75,23 +79,53 @@
            MapLibre GL JS mounts canvas into this element. -->
       <div id="map"></div>
 
-      <!-- Example property popup (hidden by default, shown on click). -->
+      <!-- Property popup shown on click of a property in vector tile layer.
+           Populated dynamically by `populatePropertyPopup` below. -->
       <div class="property-popup" id="property-popup" hidden>
-        <h3 class="popup-address">1234 Sesame St</h3>
+        <h3 class="popup-address" id="popup-address">&mdash;</h3>
         <table class="popup-details">
           <tr>
-            <td class="popup-label">Current:</td>
-            <td class="popup-value">$275,400</td>
+            <td class="popup-label">Predicted:</td>
+            <td class="popup-value" id="popup-predicted">&mdash;</td>
           </tr>
           <tr>
-            <td class="popup-label">2023:</td>
-            <td class="popup-value">$225,200</td>
+            <td class="popup-label">Tax year:</td>
+            <td class="popup-value" id="popup-tax-year">&mdash;</td>
           </tr>
           <tr>
             <td class="popup-label">Change:</td>
-            <td class="popup-value popup-change-up">&uarr; 22.3%</td>
+            <td class="popup-value" id="popup-change">&mdash;</td>
           </tr>
         </table>
+
+        <!-- Margin of Error: 80% prediction interval from quantile
+             models. Shows reviewers how confident model
+             is for this specific property. -->
+        <div class="moe-section">
+          <div class="moe-header">
+            <span class="moe-label">80% confidence range</span>
+            <span class="moe-range" id="popup-moe-range">&mdash;</span>
+          </div>
+          <div class="moe-bar" aria-hidden="true">
+            <div class="moe-bar-fill" id="popup-moe-fill"></div>
+            <div class="moe-bar-marker" id="popup-moe-marker"></div>
+          </div>
+          <div class="moe-endpoints">
+            <span id="popup-moe-low">&mdash;</span>
+            <span id="popup-moe-high">&mdash;</span>
+          </div>
+        </div>
+
+        <!-- Explainability of top features driving model, with this
+             property's value alongside each one. -->
+        <div class="drivers-section">
+          <h4 class="drivers-title">Why this prediction?</h4>
+          <ul class="drivers-list" id="popup-drivers"></ul>
+          <p class="drivers-footnote">
+            Importance reflects the model's overall reliance on each
+            feature, not its effect on this property alone.
+          </p>
+        </div>
       </div>
     </main>
   </div>
@@ -142,7 +176,7 @@
     // Fetch from public GCS bucket in future:
     // https://storage.googleapis.com/musa5090s26-team5-public/configs/tax_year_assessment_bins.json
     // Below currently uses local dummy data file.
-    const TAX_YEAR_BINS_URL = "../configs/dummy_tax_year_assessment_bins.json";
+    const TAX_YEAR_BINS_URL = "https://storage.googleapis.com/musa5090s26-team5-public/configs/tax_year_assessment_bins.json";
 
     function formatDollar(value) {
       if (value >= 1_000_000) return "$" + (value / 1_000_000).toFixed(1) + "M";
@@ -212,62 +246,294 @@
     // Fetch from public GCS bucket in future:
     // https://storage.googleapis.com/musa5090s26-team5-public/configs/current_assessment_bins.json
     // Below currently uses local dummy data file.
-    const CURRENT_BINS_URL = "../configs/dummy_current_assessment_bins.json";
+    const CURRENT_BINS_URL = "https://storage.googleapis.com/musa5090s26-team5-public/configs/current_assessment_bins.json";
+
+    let currentAssessmentChart = null;
+
+    function renderCurrentAssessmentChart(bins) {
+      const categories = bins.map((b) => {
+        const upper = b.upper_bound >= 999_999_999 ? "+" : " \u2013 " + formatDollar(b.upper_bound);
+        return formatDollar(b.lower_bound) + upper;
+      });
+      const counts = bins.map((b) => b.property_count);
+
+      const options = {
+        chart: {
+          type: "bar",
+          height: 220,
+          toolbar: { show: false },
+          fontFamily: '"Helvetica Neue", Helvetica, Arial, sans-serif',
+        },
+        series: [{ name: "Properties", data: counts }],
+        xaxis: {
+          categories,
+          labels: {
+            rotate: -45,
+            rotateAlways: true,
+            style: { fontSize: "10px" },
+          },
+        },
+        yaxis: {
+          title: { text: "# Properties" },
+          labels: {
+            formatter: (val) => val >= 1000 ? (val / 1000).toFixed(0) + "K" : val,
+          },
+        },
+        colors: ["#F2541B"],
+        plotOptions: {
+          bar: { borderRadius: 2, columnWidth: "70%" },
+        },
+        dataLabels: { enabled: false },
+        tooltip: {
+          y: {
+            formatter: (val) => val.toLocaleString() + " properties",
+          },
+        },
+      };
+
+      if (currentAssessmentChart) {
+        currentAssessmentChart.destroy();
+      }
+      currentAssessmentChart = new ApexCharts(
+        document.querySelector("#current-assessment-chart"),
+        options
+      );
+      currentAssessmentChart.render();
+    }
 
     fetch(CURRENT_BINS_URL)
       .then((res) => res.json())
-      .then((bins) => {
-        const categories = bins.map((b) => {
-          const upper = b.upper_bound >= 999_999_999 ? "+" : " \u2013 " + formatDollar(b.upper_bound);
-          return formatDollar(b.lower_bound) + upper;
+      .then((allBins) => {
+        // Populate year filter from tax_year values present in the data.
+        const years = [...new Set(allBins.map((b) => b.tax_year))].sort((a, b) => b - a);
+        const yearSelect = document.querySelector("#current-year-select");
+        years.forEach((yr) => {
+          const opt = document.createElement("option");
+          opt.value = yr;
+          opt.textContent = yr;
+          yearSelect.appendChild(opt);
         });
-        const counts = bins.map((b) => b.property_count);
 
-        const options = {
-          chart: {
-            type: "bar",
-            height: 220,
-            toolbar: { show: false },
-            fontFamily: '"Helvetica Neue", Helvetica, Arial, sans-serif',
-          },
-          series: [{ name: "Properties", data: counts }],
-          xaxis: {
-            categories,
-            labels: {
-              rotate: -45,
-              rotateAlways: true,
-              style: { fontSize: "10px" },
-            },
-          },
-          yaxis: {
-            title: { text: "# Properties" },
-            labels: {
-              formatter: (val) => val >= 1000 ? (val / 1000).toFixed(0) + "K" : val,
-            },
-          },
-          colors: ["#F2541B"],
-          plotOptions: {
-            bar: { borderRadius: 2, columnWidth: "70%" },
-          },
-          dataLabels: { enabled: false },
-          tooltip: {
-            y: {
-              formatter: (val) => val.toLocaleString() + " properties",
-            },
-          },
-        };
+        // Render chart for the most recent year on initial load.
+        const latestYear = years[0];
+        renderCurrentAssessmentChart(allBins.filter((b) => b.tax_year === latestYear));
 
-        const chart = new ApexCharts(
-          document.querySelector("#current-assessment-chart"),
-          options
-        );
-        chart.render();
+        // Re-render whenever the user selects a different year.
+        yearSelect.addEventListener("change", () => {
+          const selected = Number(yearSelect.value);
+          renderCurrentAssessmentChart(allBins.filter((b) => b.tax_year === selected));
+        });
       })
       .catch((err) => {
         console.error("Failed to load current assessment bins:", err);
         document.querySelector("#current-assessment-chart").textContent =
           "Chart data unavailable.";
       });
+  </script>
+
+  <script>
+    // Property popup with prediction, margin of error, and explainability.
+    // Currently really simple with one click handler + one render
+    // function. Work in progress.
+
+    const PROPERTY_TILES_URL =
+      "https://storage.googleapis.com/musa5090s26-team5-public/tiles/properties/{z}/{x}/{y}.pbf";
+    const PROPERTY_TILE_LAYER = "property_tile_info";
+    const FEATURE_IMPORTANCES_URL =
+      "https://storage.googleapis.com/musa5090s26-team5-public/configs/model_feature_importances.json";
+
+    // How many top features to show in explainability list.
+    const TOP_DRIVERS_COUNT = 3;
+
+    // Global importances are loaded once and reused for every popup.
+    let featureImportances = [];
+
+    // Format helpers.
+    const fmtUsd = (n) =>
+      n == null || isNaN(n)
+        ? "\u2014"
+        : "$" + Math.round(n).toLocaleString();
+    const fmtPct = (n) =>
+      n == null || isNaN(n)
+        ? "\u2014"
+        : (n * 100).toFixed(1) + "%";
+
+    // Pretty-print a feature value based on its name.
+    function formatFeatureValue(featureName, props) {
+      switch (featureName) {
+        case "total_livable_area":
+          return props.total_livable_area != null
+            ? Math.round(props.total_livable_area).toLocaleString() + " sqft"
+            : "n/a";
+        case "number_of_bathrooms":
+          return props.number_of_bathrooms != null
+            ? String(props.number_of_bathrooms)
+            : "n/a";
+        case "property_age": {
+          const yb = props.year_built;
+          if (yb == null || isNaN(yb)) return "n/a";
+          return new Date().getFullYear() - Number(yb) + " yrs";
+        }
+        case "interior_condition":
+          return props.interior_condition != null
+            ? "Grade " + props.interior_condition
+            : "n/a";
+        case "assessed_value_2023":
+          return fmtUsd(props.assessed_value_2023);
+        case "assessed_value_2024":
+          return fmtUsd(props.assessed_value_2024);
+        case "assessed_value_2025":
+          return fmtUsd(props.assessed_value_2025);
+        case "neighborhood":
+        case "neighborhood_median_price":
+          return props.neighborhood || "n/a";
+        case "sale_year":
+          return props.sale_year != null ? String(props.sale_year) : "n/a";
+        default:
+          return "n/a";
+      }
+    }
+
+    // Fill in popup using a property's tile properties + global
+    // feature importances loaded above.
+    function populatePropertyPopup(props) {
+      const popup = document.getElementById("property-popup");
+
+      document.getElementById("popup-address").textContent =
+        props.address || "Property " + (props.property_id ?? "");
+
+      const predicted = props.current_assessed_value;
+      const lower = props.current_assessed_value_lower;
+      const upper = props.current_assessed_value_upper;
+      const taxYear = props.tax_year_assessed_value;
+
+      document.getElementById("popup-predicted").textContent = fmtUsd(predicted);
+      document.getElementById("popup-tax-year").textContent =
+        taxYear != null ? fmtUsd(taxYear) + " (" + (props.tax_year ?? "") + ")" : "\u2014";
+
+      const changeEl = document.getElementById("popup-change");
+      if (props.pct_change == null || isNaN(props.pct_change)) {
+        changeEl.textContent = "\u2014";
+        changeEl.className = "popup-value";
+      } else {
+        const up = props.pct_change >= 0;
+        changeEl.textContent = (up ? "\u2191 " : "\u2193 ") + fmtPct(props.pct_change);
+        changeEl.className = "popup-value " + (up ? "popup-change-up" : "popup-change-down");
+      }
+
+      // Margin of error bar. Bar represents range
+      // [lower, upper]. Marker shows point prediction.
+      const moeRange = document.getElementById("popup-moe-range");
+      const moeFill = document.getElementById("popup-moe-fill");
+      const moeMarker = document.getElementById("popup-moe-marker");
+      const moeLow = document.getElementById("popup-moe-low");
+      const moeHigh = document.getElementById("popup-moe-high");
+
+      if (lower != null && upper != null && predicted != null && upper > lower) {
+        const halfWidth = (upper - lower) / 2;
+        const pctOfPredicted = predicted > 0 ? (halfWidth / predicted) * 100 : null;
+        moeRange.textContent =
+          "\u00B1 " +
+          fmtUsd(halfWidth) +
+          (pctOfPredicted != null ? " (" + pctOfPredicted.toFixed(0) + "%)" : "");
+        moeLow.textContent = fmtUsd(lower);
+        moeHigh.textContent = fmtUsd(upper);
+        
+        // Scale fill to span full bar. Place marker proportional
+        // to where point prediction sits in [lower, upper].
+        moeFill.style.left = "0%";
+        moeFill.style.width = "100%";
+        const pos = Math.max(0, Math.min(100, ((predicted - lower) / (upper - lower)) * 100));
+        moeMarker.style.left = pos + "%";
+        moeMarker.hidden = false;
+      } else {
+        moeRange.textContent = "\u2014";
+        moeLow.textContent = "\u2014";
+        moeHigh.textContent = "\u2014";
+        moeFill.style.width = "0%";
+        moeMarker.hidden = true;
+      }
+
+      // Explainability list. Pick top-N features and show this property's
+      // value next to each. Could consider computing per-property SHAP values
+      // in future, but would require shipping model to browser.
+      // Global importances + this property's actual feature values give
+      // reviewers a useful surface-level explanation.
+      const driversEl = document.getElementById("popup-drivers");
+      driversEl.innerHTML = "";
+      const top = featureImportances.slice(0, TOP_DRIVERS_COUNT);
+      if (top.length === 0) {
+        driversEl.innerHTML =
+          '<li class="drivers-empty">Feature importances not loaded yet.</li>';
+      } else {
+        const maxImp = top[0].importance || 1;
+        for (const f of top) {
+          const li = document.createElement("li");
+          li.className = "driver-item";
+          const widthPct = Math.round((f.importance / maxImp) * 100);
+          li.innerHTML =
+            '<div class="driver-row">' +
+            '  <span class="driver-label">' + f.label + "</span>" +
+            '  <span class="driver-value">' + formatFeatureValue(f.feature, props) + "</span>" +
+            "</div>" +
+            '<div class="driver-bar"><div class="driver-bar-fill" style="width:' + widthPct + '%"></div></div>' +
+            '<div class="driver-importance">' + (f.importance * 100).toFixed(1) + "% importance</div>";
+          driversEl.appendChild(li);
+        }
+      }
+
+      popup.hidden = false;
+    }
+
+    // Load global feature importances once. Failures are non-fatal as
+    // popup still shows prediction + MOE without drivers list.
+    fetch(FEATURE_IMPORTANCES_URL)
+      .then((res) => (res.ok ? res.json() : Promise.reject(res.status)))
+      .then((data) => {
+        featureImportances = Array.isArray(data.features) ? data.features : [];
+      })
+      .catch((err) => {
+        console.warn("Feature importances unavailable:", err);
+      });
+
+    // Hook up property tile layer + click handler once map is
+    // ready. Add a transparent fill purely so clicks register if no
+    // styled layer exists yet. If source/layer are already added
+    // elsewhere, this is safe to skip.
+    map.on("load", () => {
+      if (!map.getSource("property-tiles")) {
+        map.addSource("property-tiles", {
+          type: "vector",
+          tiles: [PROPERTY_TILES_URL],
+          minzoom: 10,
+          maxzoom: 16,
+        });
+      }
+      if (!map.getLayer("property-tiles-clickable")) {
+        map.addLayer({
+          id: "property-tiles-clickable",
+          type: "fill",
+          source: "property-tiles",
+          "source-layer": PROPERTY_TILE_LAYER,
+          paint: {
+            "fill-color": "#000000",
+            "fill-opacity": 0,
+          },
+        });
+      }
+
+      map.on("click", "property-tiles-clickable", (e) => {
+        if (!e.features || e.features.length === 0) return;
+        populatePropertyPopup(e.features[0].properties || {});
+      });
+
+      map.on("mouseenter", "property-tiles-clickable", () => {
+        map.getCanvas().style.cursor = "pointer";
+      });
+      map.on("mouseleave", "property-tiles-clickable", () => {
+        map.getCanvas().style.cursor = "";
+      });
+    });
   </script>
 </body>
 

--- a/ui/reviewer/styles.css
+++ b/ui/reviewer/styles.css
@@ -200,6 +200,15 @@ strong, b {
   box-shadow: 0 2px 6px rgb(0 0 0 / 20%);
 }
 
+@media (width <= 768px) {
+  .property-popup {
+    right: 50%;
+    transform: translateX(50%);
+    bottom: 16px;
+    max-width: 85vw;
+  }
+}
+
 .popup-address {
   font-size: 0.95rem;
   font-weight: 700;
@@ -437,14 +446,6 @@ strong, b {
     font-size: 0.75rem;
     padding: 8px 10px;
     max-width: 70vw; /* Prevent overflow on narrow screens. */
-  }
-
-  /* Move property popup to bottom-center for thumb reach. */
-  .property-popup {
-    right: 50%;
-    transform: translateX(50%);
-    bottom: 16px;
-    max-width: 85vw;
   }
 }
 

--- a/ui/reviewer/styles.css
+++ b/ui/reviewer/styles.css
@@ -195,18 +195,10 @@ strong, b {
   background: #fff;
   border: 1px solid #ccc;
   padding: 12px 16px;
-  min-width: 200px;
+  min-width: 240px;
+  max-width: 280px;
   font-size: 0.85rem;
   box-shadow: 0 2px 6px rgb(0 0 0 / 20%);
-}
-
-@media (width <= 768px) {
-  .property-popup {
-    right: 50%;
-    transform: translateX(50%);
-    bottom: 16px;
-    max-width: 85vw;
-  }
 }
 
 .popup-address {
@@ -246,12 +238,6 @@ strong, b {
    Visualizes 80% prediction interval for popup property.
    Bar runs from lower bound to upper bound. Marker
    shows where point prediction sits within that range. */
-
-.property-popup {
-  /* Allow popup to grow when explainability section is shown. */
-  min-width: 240px;
-  max-width: 280px;
-}
 
 .moe-section {
   margin-top: 10px;
@@ -446,6 +432,14 @@ strong, b {
     font-size: 0.75rem;
     padding: 8px 10px;
     max-width: 70vw; /* Prevent overflow on narrow screens. */
+  }
+
+  /* Move property popup to bottom-center for thumb reach. */
+  .property-popup {
+    right: 50%;
+    transform: translateX(50%);
+    bottom: 16px;
+    max-width: 85vw;
   }
 }
 

--- a/ui/reviewer/styles.css
+++ b/ui/reviewer/styles.css
@@ -233,6 +233,154 @@ strong, b {
   color: #F2541B;
 }
 
+/* Margin of Error (MOE) section.
+   Visualizes 80% prediction interval for popup property.
+   Bar runs from lower bound to upper bound. Marker
+   shows where point prediction sits within that range. */
+
+.property-popup {
+  /* Allow popup to grow when explainability section is shown. */
+  min-width: 240px;
+  max-width: 280px;
+}
+
+.moe-section {
+  margin-top: 10px;
+  padding-top: 8px;
+  border-top: 1px solid #eee;
+}
+
+.moe-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 4px;
+}
+
+.moe-label {
+  font-size: 0.75rem;
+  color: #555;
+  font-style: italic;
+}
+
+.moe-range {
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: #2C3968;
+}
+
+.moe-bar {
+  position: relative;
+  height: 6px;
+  background: #eee;
+  border-radius: 3px;
+  overflow: visible;
+}
+
+.moe-bar-fill {
+  position: absolute;
+  top: 0;
+  height: 100%;
+  background: #c9d0e0; /* Light navy. */
+  border-radius: 3px;
+}
+
+.moe-bar-marker {
+  position: absolute;
+  top: -2px;
+  width: 2px;
+  height: 10px;
+  background: #2C3968;
+  transform: translateX(-1px);
+}
+
+.moe-endpoints {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 3px;
+  font-size: 0.7rem;
+  color: #888;
+}
+
+/* Explainability section.
+   Lists top features driving model along with this property's
+   own value for each. Bars are scaled relative to most-important
+   feature so reviewers can eyeball relative contributions. */
+
+.drivers-section {
+  margin-top: 10px;
+  padding-top: 8px;
+  border-top: 1px solid #eee;
+}
+
+.drivers-title {
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: #2C3968;
+  margin-bottom: 6px;
+}
+
+.drivers-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.driver-item {
+  margin-bottom: 8px;
+}
+
+.driver-item:last-child {
+  margin-bottom: 0;
+}
+
+.driver-row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.78rem;
+  margin-bottom: 2px;
+}
+
+.driver-label {
+  color: #333;
+}
+
+.driver-value {
+  color: #555;
+  font-weight: 600;
+}
+
+.driver-bar {
+  height: 4px;
+  background: #f1f1f1;
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.driver-bar-fill {
+  height: 100%;
+  background: #F2541B; /* Brand orange to differentiate from MOE bar. */
+}
+
+.driver-importance {
+  font-size: 0.65rem;
+  color: #999;
+  margin-top: 2px;
+}
+
+.drivers-empty {
+  font-size: 0.75rem;
+  color: #888;
+  font-style: italic;
+}
+
+.drivers-footnote {
+  margin-top: 6px;
+  font-size: 0.65rem;
+  color: #aaa;
+  line-height: 1.3;
+}
+
 /* Utility
    Visually hides element while keeping accessible to screen readers.
    Used on <legend> inside layer toggle fieldset. */


### PR DESCRIPTION
# Description

Adds the reviewer-facing assessment dashboard, which is a static single-page app with an interactive map, distribution charts, and per-property popups showing predicted values, margin of error, and model explainability.

The UI uses vector tiles (PR #51), chart config JSON (PR #52), and feature importances JSON (PR #50) from public GCS bucket.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Small fix/change
- [ ] Documentation

## What should the reviewer know?

**Sidebar:**
- Summary stats paragraph is currently hardcoded and needs dynamic population in a follow-up.
- Predicted Assessment Value Distribution chart (ApexCharts) with year filter reads `current_assessment_bins.json`.
- Tax Year Assessment Value Distribution chart reads `tax_year_assessment_bins.json`.

**Map:**
- MapLibre GL JS with CARTO Positron basemap, centered on Philadelphia.
- Layer toggle checkboxes: current absolute values, tax year absolute values, percent change, dollar change.
- Vector tiles at `gs://…-public/tiles/properties/{z}/{x}/{y}.pbf`.

**Property popup (click):**
- Address, predicted value, tax year value, percent change with directional indicator.
- 80% confidence range bar (lower/upper from quantile models in PR #50).
- "Why this prediction?" panel of top 3 features with importance bars and this property's actual values.

Cross-reference tile property names in `populatePropertyPopup()` against SQL column aliases in PR #51 before approving.

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)